### PR TITLE
Draft of a functional VaultClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.springframework.vault</groupId>
 	<artifactId>spring-vault-parent</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.ISSUE-49-SNAPSHOT</version>
 
 	<name>Spring Vault</name>
 	<description>Parent project for Spring Vault</description>

--- a/spring-vault-core/pom.xml
+++ b/spring-vault-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.vault</groupId>
 		<artifactId>spring-vault-parent</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.ISSUE-49-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-vault-core</artifactId>

--- a/spring-vault-core/pom.xml
+++ b/spring-vault-core/pom.xml
@@ -64,6 +64,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>3.5.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultResponse;
@@ -35,7 +35,7 @@ import org.springframework.vault.support.VaultToken;
  *
  * @author Mark Paluch
  * @see AppIdAuthenticationOptions
- * @see VaultClient
+ * @see PreviousVaultClient
  * @see <a href="https://www.vaultproject.io/docs/auth/app-id.html">Auth Backend: App
  * ID</a>
  */
@@ -45,16 +45,17 @@ public class AppIdAuthentication implements ClientAuthentication {
 
 	private final AppIdAuthenticationOptions options;
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	/**
 	 * Creates a {@link AppIdAuthentication} using {@link AppIdAuthenticationOptions} and
-	 * {@link VaultClient}.
+	 * {@link PreviousVaultClient}.
 	 *
 	 * @param options must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 */
-	public AppIdAuthentication(AppIdAuthenticationOptions options, VaultClient vaultClient) {
+	public AppIdAuthentication(AppIdAuthenticationOptions options,
+			PreviousVaultClient vaultClient) {
 
 		Assert.notNull(options, "AppIdAuthenticationOptions must not be null");
 		Assert.notNull(vaultClient, "VaultClient must not be null");

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultResponse;
@@ -37,7 +37,7 @@ import org.springframework.vault.support.VaultToken;
  *
  * @author Mark Paluch
  * @see AppRoleAuthenticationOptions
- * @see VaultClient
+ * @see PreviousVaultClient
  * @see <a href="https://www.vaultproject.io/docs/auth/approle.html">Auth Backend:
  * AppRole</a>
  */
@@ -47,17 +47,17 @@ public class AppRoleAuthentication implements ClientAuthentication {
 
 	private final AppRoleAuthenticationOptions options;
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	/**
 	 * Creates a {@link AppRoleAuthentication} using {@link AppRoleAuthenticationOptions}
-	 * and {@link VaultClient}.
+	 * and {@link PreviousVaultClient}.
 	 *
 	 * @param options must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 */
 	public AppRoleAuthentication(AppRoleAuthenticationOptions options,
-			VaultClient vaultClient) {
+			PreviousVaultClient vaultClient) {
 
 		Assert.notNull(options, "AppRoleAuthenticationOptions must not be null");
 		Assert.notNull(vaultClient, "VaultClient must not be null");

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
@@ -25,7 +25,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultResponse;
@@ -51,7 +51,7 @@ public class AwsEc2Authentication implements ClientAuthentication {
 
 	private final AwsEc2AuthenticationOptions options;
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	private final RestTemplate restTemplate;
 
@@ -62,22 +62,22 @@ public class AwsEc2Authentication implements ClientAuthentication {
 	 * 
 	 * @param vaultClient must not be {@literal null}.
 	 */
-	public AwsEc2Authentication(VaultClient vaultClient) {
+	public AwsEc2Authentication(PreviousVaultClient vaultClient) {
 		this(AwsEc2AuthenticationOptions.DEFAULT, vaultClient, vaultClient
 				.getRestTemplate());
 	}
 
 	/**
 	 * Creates a new {@link AwsEc2Authentication} specifying
-	 * {@link AwsEc2AuthenticationOptions}, {@link VaultClient} and a {@link RestTemplate}
-	 * .
+	 * {@link AwsEc2AuthenticationOptions}, {@link PreviousVaultClient} and a
+	 * {@link RestTemplate} .
 	 * 
 	 * @param options must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 * @param restTemplate must not be {@literal null}.
 	 */
 	public AwsEc2Authentication(AwsEc2AuthenticationOptions options,
-			VaultClient vaultClient, RestTemplate restTemplate) {
+			PreviousVaultClient vaultClient, RestTemplate restTemplate) {
 
 		Assert.notNull(options, "AwsEc2AuthenticationOptions must not be null");
 		Assert.notNull(vaultClient, "VaultEndpoint must not be null");

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultResponse;
@@ -37,14 +37,15 @@ public class ClientCertificateAuthentication implements ClientAuthentication {
 	private final static Log logger = LogFactory
 			.getLog(ClientCertificateAuthentication.class);
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	/**
-	 * Creates a {@link ClientCertificateAuthentication} using {@link VaultClient}.
+	 * Creates a {@link ClientCertificateAuthentication} using {@link PreviousVaultClient}
+	 * .
 	 *
 	 * @param vaultClient must not be {@literal null}.
 	 */
-	public ClientCertificateAuthentication(VaultClient vaultClient) {
+	public ClientCertificateAuthentication(PreviousVaultClient vaultClient) {
 
 		Assert.notNull(vaultClient, "VaultClient must not be null");
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultResponse;
@@ -118,17 +118,17 @@ public class CubbyholeAuthentication implements ClientAuthentication {
 
 	private final CubbyholeAuthenticationOptions options;
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	/**
 	 * Create a new {@link CubbyholeAuthentication} given
-	 * {@link CubbyholeAuthenticationOptions} and {@link VaultClient}.
+	 * {@link CubbyholeAuthenticationOptions} and {@link PreviousVaultClient}.
 	 * 
 	 * @param options must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 */
 	public CubbyholeAuthentication(CubbyholeAuthenticationOptions options,
-			VaultClient vaultClient) {
+			PreviousVaultClient vaultClient) {
 
 		Assert.notNull(options, "CubbyholeAuthenticationOptions must not be null");
 		Assert.notNull(vaultClient, "VaultClient must not be null");

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
@@ -31,7 +31,7 @@ import org.springframework.scheduling.TriggerContext;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultToken;
@@ -63,7 +63,7 @@ public class LifecycleAwareSessionManager implements SessionManager, DisposableB
 			.getLog(LifecycleAwareSessionManager.class);
 
 	private final ClientAuthentication clientAuthentication;
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 	private final AsyncTaskExecutor taskExecutor;
 	private final Object lock = new Object();
 
@@ -71,14 +71,14 @@ public class LifecycleAwareSessionManager implements SessionManager, DisposableB
 
 	/**
 	 * Create a {@link LifecycleAwareSessionManager} given {@link ClientAuthentication},
-	 * {@link AsyncTaskExecutor} and {@link VaultClient}.
+	 * {@link AsyncTaskExecutor} and {@link PreviousVaultClient}.
 	 * 
 	 * @param clientAuthentication must not be {@literal null}.
 	 * @param taskExecutor must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 */
 	public LifecycleAwareSessionManager(ClientAuthentication clientAuthentication,
-			AsyncTaskExecutor taskExecutor, VaultClient vaultClient) {
+			AsyncTaskExecutor taskExecutor, PreviousVaultClient vaultClient) {
 
 		Assert.notNull(clientAuthentication, "ClientAuthentication must not be null");
 		Assert.notNull(taskExecutor, "AsyncTaskExecutor must not be null");

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/DefaultVaultClient.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/DefaultVaultClient.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.vault.support.VaultToken;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Implementation of the low-level Vault client. This client uses the Vault HTTP API to
+ * issue requests using different {@link HttpMethod HTTP methods}.
+ * {@link DefaultVaultClient} is configured with an {@link VaultEndpoint} and
+ * {@link RestTemplate}. It does not maintain any session or token state. See
+ * {@link org.springframework.vault.core.VaultTemplate} and
+ * {@link org.springframework.vault.authentication.SessionManager} for authenticated and
+ * stateful Vault access. {@link DefaultVaultClient} encapsulates base URI and path
+ * construction for request and error handling by returning {@link VaultResponseEntity}
+ * for requests.
+ *
+ * @author Mark Paluch
+ * @see VaultResponseEntity
+ * @see VaultClient
+ * @see VaultRequest
+ * @see VaultRequestBody
+ */
+public class DefaultVaultClient implements VaultClient {
+
+	public static final String VAULT_TOKEN = "X-Vault-Token";
+
+	private static final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+
+	private final VaultEndpoint endpoint;
+
+	private final RestTemplate restTemplate;
+
+	/**
+	 * Creates a new {@link PreviousVaultClient} for a {@link RestTemplate} and
+	 * {@link VaultEndpoint}.
+	 *
+	 * @param restTemplate must not be {@literal null}.
+	 * @param endpoint must not be {@literal null}.
+	 */
+	private DefaultVaultClient(RestTemplate restTemplate, VaultEndpoint endpoint) {
+
+		Assert.notNull(endpoint, "VaultEndpoint must not be null");
+		Assert.notNull(restTemplate, "RestTemplate must not be null");
+
+		this.endpoint = endpoint;
+		this.restTemplate = restTemplate;
+	}
+
+	public static VaultClient create() {
+		return new DefaultVaultClient(new RestTemplate(), new VaultEndpoint());
+	}
+
+	public static VaultClient create(RestTemplate restTemplate,
+			VaultEndpoint vaultEndpoint) {
+		return new DefaultVaultClient(restTemplate, vaultEndpoint);
+	}
+
+	public static VaultClient create(ClientHttpRequestFactory clientHttpRequestFactory,
+			VaultEndpoint vaultEndpoint) {
+		return new DefaultVaultClient(newRestTemplate(clientHttpRequestFactory),
+				vaultEndpoint);
+	}
+
+	/**
+	 * Create a {@link RestTemplate} using an interceptor given a
+	 * {@link ClientHttpRequestFactory}. This forces {@link RestTemplate} to create the
+	 * body representation instead of streaming the body to the TCP channel. Streaming the
+	 * body without knowing the size in advance will skip the
+	 * {@link HttpHeaders#CONTENT_LENGTH} makes Vault upset.
+	 * 
+	 * @param requestFactory must not be {@literal null}.
+	 * @return the {@link RestTemplate}
+	 */
+	private static RestTemplate newRestTemplate(ClientHttpRequestFactory requestFactory) {
+
+		Assert.notNull(requestFactory, "ClientHttpRequestFactory must not be null");
+
+		RestTemplate restTemplate = new RestTemplate(requestFactory);
+		restTemplate.getInterceptors().add(new ClientHttpRequestInterceptor() {
+
+			@Override
+			public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+					ClientHttpRequestExecution execution) throws IOException {
+				return execution.execute(request, body);
+			}
+		});
+
+		return restTemplate;
+	}
+
+	@Override
+	public UriSpec get() {
+		return method(HttpMethod.GET);
+	}
+
+	@Override
+	public UriSpec head() {
+		return method(HttpMethod.HEAD);
+	}
+
+	@Override
+	public UriSpec post() {
+		return method(HttpMethod.POST);
+	}
+
+	@Override
+	public UriSpec put() {
+		return method(HttpMethod.PUT);
+	}
+
+	@Override
+	public UriSpec delete() {
+		return method(HttpMethod.DELETE);
+	}
+
+	@Override
+	public UriSpec method(HttpMethod method) {
+		return new DefaultUriSpec(method);
+	}
+
+	public VaultResponseEntity<Object> exchange(VaultRequest<?> request) {
+		return exchange(request, Object.class);
+	}
+
+	public <T, S extends T> VaultResponseEntity<S> exchange(VaultRequest<?> request,
+			Class<T> returnType) {
+
+		Assert.notNull(request, "VaultRequest must not be null");
+		Assert.notNull(returnType, "Return type must not be null");
+
+		HttpEntity<Object> entity = getRequestEntity(request);
+
+		try {
+			ResponseEntity<T> response = this.restTemplate.exchange(request.url(),
+					request.method(), entity, returnType);
+
+			return new VaultResponseEntity<S>((S) response.getBody(),
+					response.getStatusCode(), request.url(), response.getStatusCode()
+							.getReasonPhrase());
+		}
+		catch (HttpStatusCodeException e) {
+			return handleCodeException(request.url(), e);
+		}
+	}
+
+	private HttpEntity<Object> getRequestEntity(VaultRequest<?> request) {
+		HttpEntity<Object> entity;
+
+		if (request.body() != VaultRequestBody.empty()) {
+			entity = new HttpEntity<Object>(request.body().getBody(), request.headers());
+		}
+		else {
+			entity = new HttpEntity<Object>(request.headers());
+		}
+		return entity;
+	}
+
+	public <T, S extends T> VaultResponseEntity<S> exchange(VaultRequest<?> request,
+			ParameterizedTypeReference<T> returnType) {
+
+		Assert.notNull(request, "VaultRequest must not be null");
+		Assert.notNull(returnType, "Return type must not be null");
+
+		HttpEntity<Object> entity = getRequestEntity(request);
+
+		try {
+			ResponseEntity<T> response = this.restTemplate.exchange(request.url(),
+					request.method(), entity, returnType);
+
+			return new VaultResponseEntity<S>((S) response.getBody(),
+					response.getStatusCode(), request.url(), response.getStatusCode()
+							.getReasonPhrase());
+		}
+		catch (HttpStatusCodeException e) {
+			return handleCodeException(request.url(), e);
+		}
+	}
+
+	private <T, S extends T> VaultResponseEntity<S> handleCodeException(URI uri,
+			HttpStatusCodeException e) {
+
+		String message = e.getResponseBodyAsString();
+
+		if (MediaType.APPLICATION_JSON.includes(e.getResponseHeaders().getContentType())) {
+			message = VaultErrorMessage.getError(message);
+		}
+
+		return new VaultResponseEntity<S>(null, e.getStatusCode(), uri, message);
+	}
+
+	/**
+	 * @return the configured {@link VaultEndpoint}.
+	 */
+	public VaultEndpoint getEndpoint() {
+		return endpoint;
+	}
+
+	/**
+	 * Build the Vault {@link URI} based on the given {@link VaultEndpoint} and
+	 * {@code pathTemplate}. URI template variables will be expanded using
+	 * {@code uriVariables}.
+	 *
+	 * @param pathTemplate must not be empty or {@literal null}.
+	 * @param uriVariables must not be {@literal null}.
+	 * @return the resolved {@link URI}.
+	 * @see org.springframework.web.util.UriComponentsBuilder
+	 */
+	protected URI buildUri(String pathTemplate, Map<String, ?> uriVariables) {
+
+		Assert.hasText(pathTemplate, "Path must not be empty");
+
+		return restTemplate.getUriTemplateHandler().expand(
+				getEndpoint().createUriString(pathTemplate), uriVariables);
+	}
+
+	/**
+	 * Build the Vault {@link URI} based on the given {@link VaultEndpoint} and
+	 * {@code pathTemplate}. URI template variables will be expanded using
+	 * {@code uriVariables}.
+	 *
+	 * @param pathTemplate must not be empty or {@literal null}.
+	 * @param uriVariables must not be {@literal null}.
+	 * @return the resolved {@link URI}.
+	 * @see org.springframework.web.util.UriComponentsBuilder
+	 */
+	protected URI buildUri(String pathTemplate, Object... uriVariables) {
+
+		Assert.hasText(pathTemplate, "Path must not be empty");
+
+		return restTemplate.getUriTemplateHandler().expand(
+				getEndpoint().createUriString(pathTemplate), uriVariables);
+	}
+
+	/**
+	 * Create {@link HttpHeaders} for a {@link VaultToken}.
+	 *
+	 * @param vaultToken must not be {@literal null}.
+	 * @return {@link HttpHeaders} for a {@link VaultToken}.
+	 */
+	static HttpHeaders createHeaders(VaultToken vaultToken) {
+
+		Assert.notNull(vaultToken, "Vault Token must not be null");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(VAULT_TOKEN, vaultToken.getToken());
+		return headers;
+	}
+
+	/**
+	 * Unwrap a wrapped response created by Vault Response Wrapping
+	 * 
+	 * @param wrappedResponse the wrapped response , must not be empty or {@literal null}.
+	 * @param responseType the type of the return value.
+	 * @return the unwrapped response.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(final String wrappedResponse, Class<T> responseType) {
+
+		Assert.hasText(wrappedResponse, "Wrapped response must not be empty");
+
+		try {
+			return (T) converter.read(responseType, new HttpInputMessage() {
+				@Override
+				public InputStream getBody() throws IOException {
+					return new ByteArrayInputStream(wrappedResponse.getBytes());
+				}
+
+				@Override
+				public HttpHeaders getHeaders() {
+					return new HttpHeaders();
+				}
+			});
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private class DefaultUriSpec implements UriSpec {
+
+		private final HttpMethod httpMethod;
+
+		DefaultUriSpec(HttpMethod httpMethod) {
+			this.httpMethod = httpMethod;
+		}
+
+		@Override
+		public HeaderSpec uri(URI uri) {
+			return new DefaultHeaderSpec(DefaultVaultRequest.method(this.httpMethod, uri));
+		}
+
+		@Override
+		public HeaderSpec uri(String uriTemplate, Object... uriVariables) {
+			return uri(buildUri(uriTemplate, uriVariables));
+		}
+
+		@Override
+		public HeaderSpec uri(String uriTemplate, Map<String, ?> uriVariables) {
+			return uri(buildUri(uriTemplate, uriVariables));
+		}
+	}
+
+	private class DefaultHeaderSpec implements HeaderSpec {
+
+		private final VaultRequest.Builder requestBuilder;
+
+		private final HttpHeaders headers = new HttpHeaders();
+
+		DefaultHeaderSpec(VaultRequest.Builder requestBuilder) {
+			this.requestBuilder = requestBuilder;
+		}
+
+		@Override
+		public HeaderSpec header(String headerName, String... headerValues) {
+			for (String headerValue : headerValues) {
+				this.headers.add(headerName, headerValue);
+			}
+			return this;
+		}
+
+		@Override
+		public HeaderSpec headers(HttpHeaders headers) {
+			this.headers.putAll(headers);
+			return this;
+		}
+
+		@Override
+		public HeaderSpec token(VaultToken vaultToken) {
+
+			Assert.notNull(vaultToken, "VaultToken must not be null");
+			header(VAULT_TOKEN, vaultToken.getToken());
+
+			return this;
+		}
+
+		@Override
+		public ReturnTypeSpec body(VaultRequestBody<?> body) {
+			return new DefaultReturnTypeSpec(this.requestBuilder.headers(this.headers)
+					.body(body));
+		}
+
+		@Override
+		public VaultResponseEntity<Void> exchange(VaultRequestBody<?> body) {
+			return body(body).exchange();
+		}
+
+		@Override
+		public VaultResponseEntity<Void> exchange() {
+			return exchange(Void.class);
+		}
+
+		@Override
+		public <T, S extends T> VaultResponseEntity<S> exchange(Class<T> returnType) {
+			return body(VaultRequestBody.empty()).exchange(returnType);
+		}
+
+		@Override
+		public <T, S extends T> VaultResponseEntity<S> exchange(
+				ParameterizedTypeReference<T> returnType) {
+			return body(VaultRequestBody.empty()).exchange(returnType);
+		}
+	}
+
+	private class DefaultReturnTypeSpec implements ReturnTypeSpec {
+
+		private final VaultRequest<?> vaultRequest;
+
+		public DefaultReturnTypeSpec(VaultRequest<?> vaultRequest) {
+			this.vaultRequest = vaultRequest;
+		}
+
+		@Override
+		public VaultResponseEntity<Void> exchange() {
+			return exchange(Void.class);
+		}
+
+		@Override
+		public <T, S extends T> VaultResponseEntity<S> exchange(Class<T> returnType) {
+			return DefaultVaultClient.this.exchange(vaultRequest, returnType);
+		}
+
+		@Override
+		public <T, S extends T> VaultResponseEntity<S> exchange(
+				ParameterizedTypeReference<T> returnType) {
+			return DefaultVaultClient.this.exchange(vaultRequest, returnType);
+		}
+	}
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/DefaultVaultRequest.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/DefaultVaultRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import java.net.URI;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ */
+class DefaultVaultRequest<T> implements VaultRequest<T> {
+
+	private final HttpMethod method;
+
+	private final URI url;
+
+	private final HttpHeaders headers;
+
+	private final VaultRequestBody<T> body;
+
+	protected DefaultVaultRequest(HttpMethod method, URI url, HttpHeaders headers,
+			VaultRequestBody<T> body) {
+
+		Assert.notNull(method, "HttpMethod must not be null!");
+		Assert.notNull(url, "URI must not be null!");
+		Assert.notNull(headers, "HttpHeaders must not be null!");
+		Assert.notNull(body, "VaultRequestBody must not be null!");
+
+		this.method = method;
+		this.url = url;
+		this.headers = HttpHeaders.readOnlyHttpHeaders(headers);
+		this.body = body;
+	}
+
+	/**
+	 * Create a builder with the given method and url.
+	 * @param method the HTTP method (GET, POST, etc)
+	 * @param url the URL
+	 * @return the created builder
+	 */
+	static Builder method(HttpMethod method, URI url) {
+		return new DefaultClientRequestBuilder(method, url);
+	}
+
+	@Override
+	public HttpMethod method() {
+		return this.method;
+	}
+
+	@Override
+	public URI url() {
+		return this.url;
+	}
+
+	@Override
+	public HttpHeaders headers() {
+		return this.headers;
+	}
+
+	@Override
+	public VaultRequestBody<T> body() {
+		return body;
+	}
+
+	static class DefaultClientRequestBuilder implements VaultRequest.Builder {
+
+		private final HttpMethod method;
+
+		private final URI url;
+
+		private final HttpHeaders headers = new HttpHeaders();
+
+		public DefaultClientRequestBuilder(HttpMethod method, URI url) {
+			this.method = method;
+			this.url = url;
+		}
+
+		@Override
+		public VaultRequest.Builder header(String headerName, String... headerValues) {
+			for (String headerValue : headerValues) {
+				this.headers.add(headerName, headerValue);
+			}
+			return this;
+		}
+
+		@Override
+		public VaultRequest.Builder headers(HttpHeaders headers) {
+			if (headers != null) {
+				this.headers.putAll(headers);
+			}
+			return this;
+		}
+
+		@Override
+		public VaultRequest<Void> build() {
+			return body(VaultRequestBody.<Void> empty());
+		}
+
+		@Override
+		public <T> VaultRequest<T> body(VaultRequestBody<T> body) {
+			return new DefaultVaultRequest<T>(method, url, headers, body);
+		}
+	}
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/PreviousVaultClient.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/PreviousVaultClient.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultToken;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Implementation of the low-level Vault client. This client uses the Vault HTTP API to
+ * issue requests using different {@link HttpMethod HTTP methods}.
+ * {@link PreviousVaultClient} is configured with an {@link VaultEndpoint} and
+ * {@link RestTemplate}. It does not maintain any session or token state. See
+ * {@link VaultTemplate} and
+ * {@link org.springframework.vault.authentication.SessionManager} for authenticated and
+ * stateful Vault access. {@link PreviousVaultClient} encapsulates base URI and path
+ * construction and uses {@link VaultAccessor} for request and error handling by returning
+ * {@link VaultResponseEntity} for requests.
+ *
+ * @author Mark Paluch
+ * @see VaultResponseEntity
+ * @see VaultTemplate
+ * @deprecated Replaced with {@link VaultClient}.
+ */
+@Deprecated
+public class PreviousVaultClient extends VaultAccessor {
+
+	public static final String VAULT_TOKEN = "X-Vault-Token";
+
+	private static final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+
+	private final VaultEndpoint endpoint;
+
+	/**
+	 * Creates a new {@link PreviousVaultClient} with a default a {@link RestTemplate} and
+	 * {@link VaultEndpoint}.
+	 *
+	 * @see VaultEndpoint
+	 */
+	public PreviousVaultClient() {
+		this(new RestTemplate(), new VaultEndpoint());
+	}
+
+	/**
+	 * Creates a new {@link PreviousVaultClient} for a {@link ClientHttpRequestFactory}
+	 * and {@link VaultEndpoint}.
+	 *
+	 * @param requestFactory must not be {@literal null}.
+	 * @param endpoint must not be {@literal null}.
+	 */
+	public PreviousVaultClient(ClientHttpRequestFactory requestFactory,
+			VaultEndpoint endpoint) {
+
+		super(newRestTemplate(requestFactory));
+
+		Assert.notNull(endpoint, "VaultEndpoint must not be null");
+		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Create a {@link RestTemplate} using an interceptor given a
+	 * {@link ClientHttpRequestFactory}. This forces {@link RestTemplate} to create the
+	 * body representation instead of streaming the body to the TCP channel. Streaming the
+	 * body without knowing the size in advance will skip the
+	 * {@link HttpHeaders#CONTENT_LENGTH} makes Vault upset.
+	 * 
+	 * @param requestFactory must not be {@literal null}.
+	 * @return the {@link RestTemplate}
+	 */
+	private static RestTemplate newRestTemplate(ClientHttpRequestFactory requestFactory) {
+
+		Assert.notNull(requestFactory, "ClientHttpRequestFactory must not be null");
+
+		RestTemplate restTemplate = new RestTemplate(requestFactory);
+		restTemplate.getInterceptors().add(new ClientHttpRequestInterceptor() {
+
+			@Override
+			public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+					ClientHttpRequestExecution execution) throws IOException {
+				return execution.execute(request, body);
+			}
+		});
+
+		return restTemplate;
+	}
+
+	/**
+	 * Creates a new {@link PreviousVaultClient} for a {@link RestTemplate} and
+	 * {@link VaultEndpoint}.
+	 *
+	 * @param restTemplate must not be {@literal null}.
+	 * @param endpoint must not be {@literal null}.
+	 */
+	public PreviousVaultClient(RestTemplate restTemplate, VaultEndpoint endpoint) {
+
+		super(restTemplate);
+
+		Assert.notNull(endpoint, "VaultEndpoint must not be null");
+		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Retrieve a resource by GETting from the path, and returns the response as
+	 * {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> getForEntity(String path,
+			Class<T> responseType) {
+		return exchange(path, HttpMethod.GET, new HttpEntity<Object>(null), responseType,
+				null);
+	}
+
+	/**
+	 * Retrieve a resource by GETting from the path, and returns the response as
+	 * {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param vaultToken the {@link VaultToken}.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> getForEntity(String path,
+			VaultToken vaultToken, Class<T> responseType) {
+
+		return exchange(path, HttpMethod.GET, new HttpEntity<Object>(null,
+				createHeaders(vaultToken)), responseType, null);
+	}
+
+	/**
+	 * Issue a POST request using the given object to the path, and returns the response
+	 * as {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param request the Object to be POSTed, may be {@code null}.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> postForEntity(String path,
+			Object request, Class<T> responseType) {
+		return exchange(path, HttpMethod.POST, new HttpEntity<Object>(request),
+				responseType, null);
+	}
+
+	/**
+	 * Issue a POST request using the given object to the path, and returns the response
+	 * as {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param vaultToken the {@link VaultToken}.
+	 * @param request the Object to be POSTed, may be {@code null}.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> postForEntity(String path,
+			VaultToken vaultToken, Object request, Class<T> responseType) {
+		return exchange(path, HttpMethod.POST, new HttpEntity<Object>(request,
+				createHeaders(vaultToken)), responseType, null);
+	}
+
+	/**
+	 * Create a new resource by PUTting the given object to the path, and returns the
+	 * response as {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param request the Object to be PUT.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> putForEntity(String path,
+			Object request, Class<T> responseType) {
+		return exchange(path, HttpMethod.PUT, new HttpEntity<Object>(request),
+				responseType, null);
+	}
+
+	/**
+	 * Create a new resource by PUTting the given object to the path, and returns the
+	 * response as {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param vaultToken the {@link VaultToken}.
+	 * @param request the Object to be PUT.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> putForEntity(String path,
+			VaultToken vaultToken, Object request, Class<T> responseType) {
+		return exchange(path, HttpMethod.PUT, new HttpEntity<Object>(request,
+				createHeaders(vaultToken)), responseType, null);
+	}
+
+	/**
+	 * Delete a resource by DELETEing from the path, and returns the response as
+	 * {@link VaultResponseEntity}.
+	 *
+	 * @param path the path.
+	 * @param vaultToken the {@link VaultToken}.
+	 * @param responseType the type of the return value
+	 * @return the response as entity.
+	 * @see VaultResponseEntity
+	 */
+	public <T, S extends T> VaultResponseEntity<S> deleteForEntity(String path,
+			VaultToken vaultToken, Class<T> responseType) {
+
+		return exchange(path, HttpMethod.DELETE, new HttpEntity<Object>(null,
+				createHeaders(vaultToken)), responseType, null);
+	}
+
+	/**
+	 * Execute the HTTP method to the given URI template, writing the given request entity
+	 * to the request, and returns the response as {@link VaultResponseEntity}. URI
+	 * Template variables are using the given URI variables, if any.
+	 *
+	 * @param pathTemplate the path template.
+	 * @param method the HTTP method (GET, POST, etc).
+	 * @param requestEntity the entity (headers and/or body) to write to the request, may
+	 * be {@code null}.
+	 * @param responseType the type of the return value.
+	 * @param uriVariables the variables to expand in the template.
+	 * @return the response as entity.
+	 */
+	public <T, S extends T> VaultResponseEntity<S> exchange(String pathTemplate,
+			HttpMethod method, HttpEntity<?> requestEntity, Class<T> responseType,
+			Map<String, ?> uriVariables) throws RestClientException {
+
+		Assert.hasText(pathTemplate, "Path template must not be null or empty");
+		Assert.isTrue(!pathTemplate.startsWith("/"),
+				"Path template must not start with a slash (/)");
+
+		URI uri = uriVariables != null ? buildUri(pathTemplate, uriVariables)
+				: getEndpoint().createUri(pathTemplate);
+
+		return exchange(uri, method, requestEntity, responseType);
+	}
+
+	/**
+	 * Execute the HTTP method to the given path template, writing the given request
+	 * entity to the request, and returns the response as {@link VaultResponseEntity}. The
+	 * given {@link ParameterizedTypeReference} is used to pass generic type information:
+	 *
+	 * <pre class="code">
+	 * ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt; myBean = new ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt;() {
+	 * };
+	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = client.exchange(&quot;http://example.com&quot;,
+	 * 		HttpMethod.GET, null, myBean, null);
+	 * </pre>
+	 *
+	 * @param pathTemplate the path template.
+	 * @param method the HTTP method (GET, POST, etc).
+	 * @param requestEntity the entity (headers and/or body) to write to the request, may
+	 * be {@code null}.
+	 * @param responseType the type of the return value.
+	 * @param uriVariables the variables to expand in the template.
+	 * @return the response as entity.
+	 */
+	public <T, S extends T> VaultResponseEntity<S> exchange(String pathTemplate,
+			HttpMethod method, HttpEntity<?> requestEntity,
+			ParameterizedTypeReference<T> responseType, Map<String, ?> uriVariables)
+			throws RestClientException {
+
+		Assert.hasText(pathTemplate, "Path template must not be null or empty");
+		Assert.isTrue(!pathTemplate.startsWith("/"),
+				"Path template must not start with a slash (/)");
+
+		URI uri = uriVariables != null ? buildUri(pathTemplate, uriVariables)
+				: getEndpoint().createUri(pathTemplate);
+
+		return exchange(uri, method, requestEntity, responseType);
+	}
+
+	/**
+	 * Executes a {@link RestTemplateCallback}. Allows to interact with the underlying
+	 * {@link RestTemplate} and benefit from optional parameter expansion.
+	 *
+	 * @param pathTemplate the path template.
+	 * @param uriVariables the variables to expand in the template
+	 * @param callback the request.
+	 * @return the {@link RestTemplateCallback} return value.
+	 */
+	public <T> T doWithRestTemplate(String pathTemplate, Map<String, ?> uriVariables,
+			RestTemplateCallback<T> callback) {
+
+		Assert.hasText(pathTemplate, "Path template must not be null or empty");
+		Assert.isTrue(!pathTemplate.startsWith("/"),
+				"Path template must not start with a slash (/)");
+
+		URI uri = uriVariables != null ? buildUri(pathTemplate, uriVariables)
+				: getEndpoint().createUri(pathTemplate);
+
+		return super.doWithRestTemplate(uri, callback);
+	}
+
+	/**
+	 * @return the configured {@link VaultEndpoint}.
+	 */
+	public VaultEndpoint getEndpoint() {
+		return endpoint;
+	}
+
+	/**
+	 * Build the Vault {@link URI} based on the given {@link VaultEndpoint} and
+	 * {@code pathTemplate}. URI template variables will be expanded using
+	 * {@code uriVariables}.
+	 *
+	 * @param pathTemplate must not be empty or {@literal null}.
+	 * @param uriVariables must not be {@literal null}.
+	 * @return the resolved {@link URI}.
+	 * @see org.springframework.web.util.UriComponentsBuilder
+	 */
+	protected URI buildUri(String pathTemplate, Map<String, ?> uriVariables) {
+
+		Assert.hasText(pathTemplate, "Path must not be empty");
+
+		return getRestTemplate().getUriTemplateHandler().expand(
+				getEndpoint().createUriString(pathTemplate), uriVariables);
+	}
+
+	/**
+	 * Create {@link HttpHeaders} for a {@link VaultToken}.
+	 *
+	 * @param vaultToken must not be {@literal null}.
+	 * @return {@link HttpHeaders} for a {@link VaultToken}.
+	 */
+	public static HttpHeaders createHeaders(VaultToken vaultToken) {
+
+		Assert.notNull(vaultToken, "Vault Token must not be null");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(VAULT_TOKEN, vaultToken.getToken());
+		return headers;
+	}
+
+	/**
+	 * Unwrap a wrapped response created by Vault Response Wrapping
+	 * 
+	 * @param wrappedResponse the wrapped response , must not be empty or {@literal null}.
+	 * @param responseType the type of the return value.
+	 * @return the unwrapped response.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(final String wrappedResponse, Class<T> responseType) {
+
+		Assert.hasText(wrappedResponse, "Wrapped response must not be empty");
+
+		try {
+			return (T) converter.read(responseType, new HttpInputMessage() {
+				@Override
+				public InputStream getBody() throws IOException {
+					return new ByteArrayInputStream(wrappedResponse.getBytes());
+				}
+
+				@Override
+				public HttpHeaders getHeaders() {
+					return new HttpHeaders();
+				}
+			});
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultAccessor.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultAccessor.java
@@ -30,11 +30,13 @@ import org.springframework.web.client.RestTemplate;
  * Base class for Vault accessing helpers, defining common properties such as the
  * {@link RestTemplate} to operate on.
  * <p>
- * Not intended to be used directly. See {@link VaultClient}.
+ * Not intended to be used directly. See {@link PreviousVaultClient}.
  *
  * @author Spencer Gibb
  * @author Mark Paluch
+ * @deprecated Replaced with {@link VaultClient}.
  */
+@Deprecated
 public abstract class VaultAccessor {
 
 	private final RestTemplate restTemplate;

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultEndpoint.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultEndpoint.java
@@ -51,7 +51,8 @@ public class VaultEndpoint implements Serializable {
 	private String scheme = "https";
 
 	/**
-	 * Create a {@link VaultEndpoint} given a {@code host} and {@code port}.
+	 * Create a secure {@link VaultEndpoint} given a {@code host} and {@code port} using
+	 * {@literal https}.
 	 * 
 	 * @param host must not be empty or {@literal null}.
 	 * @param port must be a valid port in the range of 1-65535
@@ -65,6 +66,23 @@ public class VaultEndpoint implements Serializable {
 
 		vaultEndpoint.setHost(host);
 		vaultEndpoint.setPort(port);
+
+		return vaultEndpoint;
+	}
+
+	/**
+	 * Create a plaintext {@link VaultEndpoint} given a {@code host} and {@code port}
+	 * using {@literal http}.
+	 * 
+	 * @param host must not be empty or {@literal null}.
+	 * @param port must be a valid port in the range of 1-65535
+	 * @return a new {@link VaultEndpoint}.
+	 */
+	public static VaultEndpoint plain(String host, int port) {
+
+		VaultEndpoint vaultEndpoint = create(host, port);
+
+		vaultEndpoint.setScheme("http");
 
 		return vaultEndpoint;
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultRequest.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import java.net.URI;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+/**
+ * @author Mark Paluch
+ */
+public interface VaultRequest<T> {
+
+	/**
+	 * @return the HTTP method of this request..
+	 */
+	HttpMethod method();
+
+	/**
+	 * @return the request URI.
+	 */
+	URI url();
+
+	/**
+	 * @return the headers of this request.
+	 */
+	HttpHeaders headers();
+
+	/**
+	 * @return the {@link VaultRequestBody} of this request.
+	 */
+	VaultRequestBody<T> body();
+
+	/**
+	 * Defines a builder for a request.
+	 */
+	interface Builder {
+
+		/**
+		 * Add the given, single header value under the given name.
+		 * @param headerName the header name, must not be {@literal null}.
+		 * @param headerValues the header value(s), must not be {@literal null}.
+		 * @return {@code this} builder.
+		 * @see HttpHeaders#add(String, String)
+		 */
+		Builder header(String headerName, String... headerValues);
+
+		/**
+		 * Copy the given headers into the entity's headers map.
+		 *
+		 * @param headers the existing HttpHeaders to copy from, must not be
+		 * {@literal null}.
+		 * @return {@code this} builder.
+		 */
+		Builder headers(HttpHeaders headers);
+
+		/**
+		 * Builds the request entity with no body.
+		 * 
+		 * @return the request entity.
+		 */
+		VaultRequest<Void> build();
+
+		/**
+		 * Set the body of the request to the given {@link VaultRequestBody} and return
+		 * it.
+		 * 
+		 * @param body the {@link VaultRequestBody} that writes to the request, must not
+		 * be {@literal null}.
+		 * @param <T> the type contained in the body
+		 * @return the request entity.
+		 */
+		<T> VaultRequest<T> body(VaultRequestBody<T> body);
+	}
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultRequestBody.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultRequestBody.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import org.springframework.util.Assert;
+
+/**
+ * Encapsulates a typed Vault request body.
+ * 
+ * <p>
+ * Example use:
+ * 
+ * <pre class="code">
+ * VaultRequestBody.just(&quot;{'token': 'example'}&quot;);
+ * 
+ * VaultRequestBody.empty();
+ * </pre>
+ *
+ * @author Mark Paluch
+ */
+public abstract class VaultRequestBody<T> {
+
+	/**
+	 * Create a new {@link VaultRequestBody} that contains the specified body object.
+	 * 
+	 * @param body the body object, must not be {@literal null}.
+	 * @param <T> type of the body object.
+	 * @return the {@link VaultRequestBody} containing the body object.
+	 */
+	public static <T> VaultRequestBody<T> just(T body) {
+		return new ScalarVaultRequestBody<T>(body);
+	}
+
+	/**
+	 * Create an empty {@link VaultRequestBody} without a body object.
+	 * 
+	 * @param <T> type of the body object.
+	 * @return the empty {@link VaultRequestBody}.
+	 */
+	public static <T> VaultRequestBody<T> empty() {
+		return EmptyVaultRequestBody.instance();
+	}
+
+	/**
+	 * @return the body object of this {@link VaultRequestBody}.
+	 */
+	public abstract T getBody();
+
+	/**
+	 * Represents a scalar {@link VaultRequestBody} holding a singleton {@code body}
+	 * object.
+	 */
+	static class ScalarVaultRequestBody<T> extends VaultRequestBody<T> {
+
+		private final T body;
+
+		public ScalarVaultRequestBody(T body) {
+
+			Assert.notNull(body, "Body must not be null");
+
+			this.body = body;
+		}
+
+		@Override
+		public T getBody() {
+			return body;
+		}
+	}
+
+	/**
+	 * Represents an empty {@link VaultRequestBody} which returns {@literal null} on
+	 * {@link #getBody()}.
+	 */
+	static class EmptyVaultRequestBody<T> extends VaultRequestBody<T> {
+
+		private final static EmptyVaultRequestBody<Object> INSTANCE = new EmptyVaultRequestBody<Object>();
+
+		/**
+		 * Returns a properly parametrized instance of this empty {@link VaultRequestBody}
+		 * .
+		 *
+		 * @param <T> the output type
+		 * @return a properly parametrized instance of this empty {@link VaultRequestBody}
+		 * .
+		 */
+		@SuppressWarnings("unchecked")
+		public static <T> VaultRequestBody<T> instance() {
+			return (VaultRequestBody<T>) INSTANCE;
+		}
+
+		@Override
+		public T getBody() {
+			return null;
+		}
+	}
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponseEntity.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponseEntity.java
@@ -18,6 +18,7 @@ package org.springframework.vault.client;
 import java.net.URI;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
 
 /**
  * Encapsulates the client response used in {@link VaultAccessor}. Consists of the body,
@@ -36,7 +37,19 @@ public class VaultResponseEntity<T> {
 
 	private final String message;
 
+	/**
+	 * Create a new {@link VaultResponseEntity} given {@link HttpStatus} and {@link URI}.
+	 * {@code}
+	 * @param body optional body for this response, may be {@literal null}.
+	 * @param statusCode the status code, must not be {@literal null}.
+	 * @param uri the status code, must not be {@literal null}.
+	 * @param message optional message, may be {@literal null}.
+	 */
 	protected VaultResponseEntity(T body, HttpStatus statusCode, URI uri, String message) {
+
+		Assert.notNull(statusCode, "HttpStatusCode must not be null");
+		Assert.notNull(uri, "URI must not be null");
+
 		this.body = body;
 		this.statusCode = statusCode;
 		this.uri = uri;
@@ -58,7 +71,7 @@ public class VaultResponseEntity<T> {
 	}
 
 	/**
-	 * @return the body of this entity.
+	 * @return the body of this entity, may be {@literal null} if absent.
 	 */
 	public T getBody() {
 		return body;

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/DefaultVaultClientFactory.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/DefaultVaultClientFactory.java
@@ -16,42 +16,53 @@
 package org.springframework.vault.core;
 
 import org.springframework.util.Assert;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.web.client.RestTemplate;
 
 /**
  * Default implementation of {@link VaultClientFactory}. Returns the provided
- * {@link VaultClient}.
+ * {@link PreviousVaultClient}.
  *
  * @author Mark Paluch
  */
 public class DefaultVaultClientFactory implements VaultClientFactory {
 
+	private final PreviousVaultClient previousVaultClient;
 	private final VaultClient vaultClient;
 
 	/**
 	 * Creates a new {@link DefaultVaultClientFactory} returning always the same
-	 * {@link VaultClient}.
+	 * {@link PreviousVaultClient}.
 	 * 
+	 * @param previousVaultClient must not be {@literal null}.
 	 * @param vaultClient must not be {@literal null}.
 	 */
-	public DefaultVaultClientFactory(VaultClient vaultClient) {
+	public DefaultVaultClientFactory(PreviousVaultClient previousVaultClient,
+			VaultClient vaultClient) {
 
+		Assert.notNull(previousVaultClient, "VaultClient must not be null");
 		Assert.notNull(vaultClient, "VaultClient must not be null");
 
+		this.previousVaultClient = previousVaultClient;
 		this.vaultClient = vaultClient;
 	}
 
 	/**
-	 * Creates a new {@link DefaultVaultClientFactory} using a default {@link VaultClient}
-	 * and {@link VaultEndpoint}. Will use Vault at {@code https://localhost:8200} .
+	 * Creates a new {@link DefaultVaultClientFactory} using a default
+	 * {@link PreviousVaultClient} and {@link VaultEndpoint}. Will use Vault at
+	 * {@code https://localhost:8200} .
 	 * 
-	 * @see VaultClient
+	 * @see PreviousVaultClient
 	 * @see VaultEndpoint
 	 */
 	public DefaultVaultClientFactory() {
-		this(new VaultClient(new RestTemplate(), new VaultEndpoint()));
+		this(new PreviousVaultClient(new RestTemplate(), new VaultEndpoint()), null);
+	}
+
+	public PreviousVaultClient getPreviousVaultClient() {
+		return previousVaultClient;
 	}
 
 	@Override

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultClientFactory.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultClientFactory.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.vault.core;
 
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultClient;
 
 /**
@@ -25,6 +26,12 @@ import org.springframework.vault.client.VaultClient;
 public interface VaultClientFactory {
 
 	/**
+	 * @return a {@link PreviousVaultClient}.
+	 */
+	PreviousVaultClient getPreviousVaultClient();
+
+	/**
+	 * 
 	 * @return a {@link VaultClient}.
 	 */
 	VaultClient getVaultClient();

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultOperations.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultClient;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.client.VaultAccessor.RestTemplateCallback;
@@ -30,12 +31,12 @@ import org.springframework.vault.support.VaultResponseSupport;
 /**
  * Interface that specifies a basic set of Vault operations, implemented by
  * {@link VaultTemplate}. This is the main entry point to interact with Vault in an
- * authenticated and unauthenticated context with configured {@link VaultClient}
+ * authenticated and unauthenticated context with configured {@link PreviousVaultClient}
  * instances.
  * <p>
- * {@link VaultOperations} resolves {@link VaultClient} instances and allows execution of
- * callback methods on various levels. Callbacks can execute requests within a
- * {@link VaultOperations#doWithVault(SessionCallback) session}, the
+ * {@link VaultOperations} resolves {@link PreviousVaultClient} instances and allows
+ * execution of callback methods on various levels. Callbacks can execute requests within
+ * a {@link VaultOperations#doWithVault(SessionCallback) session}, the
  * {@link VaultOperations#doWithVault(ClientCallback) client (without requiring a
  * session)} and a
  * {@link VaultOperations#doWithRestTemplate(String, Map, RestTemplateCallback) low-level}
@@ -45,7 +46,7 @@ import org.springframework.vault.support.VaultResponseSupport;
  * @see VaultOperations#doWithVault(ClientCallback)
  * @see VaultOperations#doWithVault(SessionCallback)
  * @see VaultOperations#doWithRestTemplate(String, Map, RestTemplateCallback)
- * @see VaultClient
+ * @see PreviousVaultClient
  * @see VaultTemplate
  * @see VaultTokenOperations
  * @see org.springframework.vault.authentication.SessionManager
@@ -135,7 +136,7 @@ public interface VaultOperations {
 
 	/**
 	 * Executes a Vault {@link ClientCallback}. Allows to interact with Vault using
-	 * {@link VaultClient} without requiring a session.
+	 * {@link PreviousVaultClient} without requiring a session.
 	 *
 	 * @param clientCallback the request.
 	 * @return the {@link ClientCallback} return value.

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.vault.client.VaultAccessor;
 import org.springframework.vault.client.VaultClient;
 import org.springframework.vault.client.VaultException;
+import org.springframework.vault.client.VaultRequestBody;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.core.VaultOperations.ClientCallback;
 import org.springframework.vault.core.VaultOperations.SessionCallback;
@@ -89,8 +90,8 @@ public class VaultSysTemplate implements VaultSysOperations {
 			@Override
 			public Boolean doWithVault(VaultClient client) {
 
-				VaultResponseEntity<Map<String, Boolean>> response = client.getForEntity(
-						"sys/init", Map.class);
+				VaultResponseEntity<Map<String, Boolean>> response = client.get()
+						.uri("sys/init").exchange(Map.class);
 
 				if (response.isSuccessful() && response.hasBody()) {
 					return response.getBody().get("initialized");
@@ -114,8 +115,9 @@ public class VaultSysTemplate implements VaultSysOperations {
 					public VaultInitializationResponse doWithVault(VaultClient client) {
 
 						VaultResponseEntity<VaultInitializationResponseImpl> response = client
-								.putForEntity("sys/init", vaultInitializationRequest,
-										VaultInitializationResponseImpl.class);
+								.post().uri("sys/init")
+								.body(VaultRequestBody.just(vaultInitializationRequest))
+								.exchange(VaultInitializationResponseImpl.class);
 
 						if (response.isSuccessful() && response.hasBody()) {
 							return response.getBody();
@@ -140,9 +142,10 @@ public class VaultSysTemplate implements VaultSysOperations {
 			public VaultUnsealStatus doWithVault(VaultClient client) {
 
 				VaultResponseEntity<VaultUnsealStatusImpl> response = client
-						.putForEntity("sys/unseal",
-								Collections.singletonMap("key", keyShare),
-								VaultUnsealStatusImpl.class);
+						.put()
+						.uri("sys/unseal")
+						.body(VaultRequestBody.just(Collections.singletonMap("key",
+								keyShare))).exchange(VaultUnsealStatusImpl.class);
 
 				if (response.isSuccessful() && response.hasBody()) {
 					return response.getBody();
@@ -206,7 +209,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 	@Override
 	public VaultHealth health() {
 		return vaultOperations.doWithRestTemplate("sys/health",
-				Collections.<String, Object>emptyMap(), HEALTH);
+				Collections.<String, Object> emptyMap(), HEALTH);
 	}
 
 	private static String buildExceptionMessage(VaultResponseEntity<?> response) {
@@ -225,8 +228,8 @@ public class VaultSysTemplate implements VaultSysOperations {
 		@Override
 		public VaultUnsealStatus doWithVault(VaultClient client) {
 
-			VaultResponseEntity<VaultUnsealStatusImpl> response = client.getForEntity(
-					"sys/seal-status", VaultUnsealStatusImpl.class);
+			VaultResponseEntity<VaultUnsealStatusImpl> response = client.get()
+					.uri("sys/seal-status").exchange(VaultUnsealStatusImpl.class);
 
 			if (response.isSuccessful() && response.hasBody()) {
 				return response.getBody();
@@ -268,7 +271,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 
 			VaultResponseEntity<VaultMountsResponse> response = session.exchange(path,
 					HttpMethod.GET, null, MOUNT_TYPE_REF,
-					Collections.<String, Object>emptyMap());
+					Collections.<String, Object> emptyMap());
 
 			if (response.isSuccessful() && response.hasBody()) {
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultResponse.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultResponse.java
@@ -18,8 +18,6 @@ package org.springframework.vault.support;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * Value object to bind generic Vault HTTP API responses.
  * <p>

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppIdAuthenticationIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppIdAuthenticationIntegrationTests.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.core.VaultOperations;
@@ -80,7 +80,8 @@ public class AppIdAuthenticationIntegrationTests extends IntegrationTestSupport 
 				.userIdMechanism(new StaticUserId("static-userid-value")) //
 				.build();
 
-		VaultClient vaultClient = new VaultClient(TestRestTemplateFactory.create(Settings
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				TestRestTemplateFactory.create(Settings
 				.createSslConfiguration()), new VaultEndpoint());
 
 		AppIdAuthentication authentication = new AppIdAuthentication(options, vaultClient);
@@ -97,7 +98,8 @@ public class AppIdAuthenticationIntegrationTests extends IntegrationTestSupport 
 				.userIdMechanism(new StaticUserId("wrong")) //
 				.build();
 
-		VaultClient vaultClient = new VaultClient(TestRestTemplateFactory.create(Settings
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				TestRestTemplateFactory.create(Settings
 				.createSslConfiguration()), new VaultEndpoint());
 
 		new AppIdAuthentication(options, vaultClient).login();

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppIdAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppIdAuthenticationUnitTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.support.VaultToken;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 public class AppIdAuthenticationUnitTests {
 
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 	private MockRestServiceServer mockRest;
 
 	@Before
@@ -49,7 +49,7 @@ public class AppIdAuthenticationUnitTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		mockRest = MockRestServiceServer.createServer(restTemplate);
-		vaultClient = new VaultClient(restTemplate, new VaultEndpoint());
+		vaultClient = new PreviousVaultClient(restTemplate, new VaultEndpoint());
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppRoleAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppRoleAuthenticationUnitTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.support.VaultToken;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 public class AppRoleAuthenticationUnitTests {
 
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 	private MockRestServiceServer mockRest;
 
 	@Before
@@ -49,7 +49,7 @@ public class AppRoleAuthenticationUnitTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		mockRest = MockRestServiceServer.createServer(restTemplate);
-		vaultClient = new VaultClient(restTemplate, new VaultEndpoint());
+		vaultClient = new PreviousVaultClient(restTemplate, new VaultEndpoint());
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.support.VaultToken;
@@ -44,7 +44,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 public class AwsEc2AuthenticationUnitTests {
 
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 	private MockRestServiceServer mockRest;
 
 	@Before
@@ -52,7 +52,7 @@ public class AwsEc2AuthenticationUnitTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		mockRest = MockRestServiceServer.createServer(restTemplate);
-		vaultClient = new VaultClient(restTemplate, new VaultEndpoint());
+		vaultClient = new PreviousVaultClient(restTemplate, new VaultEndpoint());
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/ClientCertificateAuthenticationIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/ClientCertificateAuthenticationIntegrationTests.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.springframework.core.NestedRuntimeException;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.config.ClientHttpRequestFactoryFactory;
 import org.springframework.vault.core.VaultOperations;
@@ -80,7 +80,8 @@ public class ClientCertificateAuthenticationIntegrationTests extends
 
 		ClientHttpRequestFactory clientHttpRequestFactory = ClientHttpRequestFactoryFactory
 				.create(new ClientOptions(), prepareCertAuthenticationMethod());
-		VaultClient vaultClient = new VaultClient(clientHttpRequestFactory,
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				clientHttpRequestFactory,
 				new VaultEndpoint());
 
 		ClientCertificateAuthentication authentication = new ClientCertificateAuthentication(
@@ -97,7 +98,8 @@ public class ClientCertificateAuthenticationIntegrationTests extends
 
 		ClientHttpRequestFactory clientHttpRequestFactory = ClientHttpRequestFactoryFactory
 				.create(new ClientOptions(), Settings.createSslConfiguration());
-		VaultClient vaultClient = new VaultClient(clientHttpRequestFactory,
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				clientHttpRequestFactory,
 				new VaultEndpoint());
 
 		new ClientCertificateAuthentication(vaultClient).login();

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/ClientCertificateAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/ClientCertificateAuthenticationUnitTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.support.VaultToken;
@@ -40,7 +40,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 public class ClientCertificateAuthenticationUnitTests {
 
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 	private MockRestServiceServer mockRest;
 
 	@Before
@@ -48,7 +48,7 @@ public class ClientCertificateAuthenticationUnitTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		mockRest = MockRestServiceServer.createServer(restTemplate);
-		vaultClient = new VaultClient(restTemplate, new VaultEndpoint());
+		vaultClient = new PreviousVaultClient(restTemplate, new VaultEndpoint());
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/CubbyholeAuthenticationIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/CubbyholeAuthenticationIntegrationTests.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.client.VaultResponseEntity;
@@ -73,7 +73,8 @@ public class CubbyholeAuthenticationIntegrationTests extends IntegrationTestSupp
 		CubbyholeAuthenticationOptions options = CubbyholeAuthenticationOptions.builder()
 				.initialToken(VaultToken.of(initialToken)).wrapped().build();
 
-		VaultClient vaultClient = new VaultClient(TestRestTemplateFactory.create(Settings
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				TestRestTemplateFactory.create(Settings
 				.createSslConfiguration()), new VaultEndpoint());
 
 		CubbyholeAuthentication authentication = new CubbyholeAuthentication(options,
@@ -88,7 +89,8 @@ public class CubbyholeAuthenticationIntegrationTests extends IntegrationTestSupp
 		CubbyholeAuthenticationOptions options = CubbyholeAuthenticationOptions.builder()
 				.initialToken(VaultToken.of("Hello")).wrapped().build();
 
-		VaultClient vaultClient = new VaultClient(TestRestTemplateFactory.create(Settings
+		PreviousVaultClient vaultClient = new PreviousVaultClient(
+				TestRestTemplateFactory.create(Settings
 				.createSslConfiguration()), new VaultEndpoint());
 
 		CubbyholeAuthentication authentication = new CubbyholeAuthentication(options,

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/CubbyholeAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/CubbyholeAuthenticationUnitTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.client.VaultException;
 import org.springframework.vault.support.VaultToken;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  */
 public class CubbyholeAuthenticationUnitTests {
 
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 	private MockRestServiceServer mockRest;
 
 	@Before
@@ -49,7 +49,7 @@ public class CubbyholeAuthenticationUnitTests {
 
 		RestTemplate restTemplate = new RestTemplate();
 		mockRest = MockRestServiceServer.createServer(restTemplate);
-		vaultClient = new VaultClient(restTemplate, new VaultEndpoint());
+		vaultClient = new PreviousVaultClient(restTemplate, new VaultEndpoint());
 	}
 
 	@Test
@@ -59,7 +59,7 @@ public class CubbyholeAuthenticationUnitTests {
 				//
 				.andExpect(method(HttpMethod.GET))
 				//
-				.andExpect(header(VaultClient.VAULT_TOKEN, "hello"))
+				.andExpect(header(PreviousVaultClient.VAULT_TOKEN, "hello"))
 				//
 				.andRespond(
 						withSuccess()
@@ -85,7 +85,7 @@ public class CubbyholeAuthenticationUnitTests {
 
 		mockRest.expect(requestTo("https://localhost:8200/v1/cubbyhole/token")) //
 				.andExpect(method(HttpMethod.GET)) //
-				.andExpect(header(VaultClient.VAULT_TOKEN, "hello"))
+				.andExpect(header(PreviousVaultClient.VAULT_TOKEN, "hello"))
 				//
 				.andRespond(
 						withSuccess()
@@ -111,7 +111,7 @@ public class CubbyholeAuthenticationUnitTests {
 				//
 				.andExpect(method(HttpMethod.GET))
 				//
-				.andExpect(header(VaultClient.VAULT_TOKEN, "hello"))
+				.andExpect(header(PreviousVaultClient.VAULT_TOKEN, "hello"))
 				//
 				.andRespond(
 						withSuccess().contentType(MediaType.APPLICATION_JSON).body(
@@ -139,7 +139,7 @@ public class CubbyholeAuthenticationUnitTests {
 				//
 				.andExpect(method(HttpMethod.GET))
 				//
-				.andExpect(header(VaultClient.VAULT_TOKEN, "hello"))
+				.andExpect(header(PreviousVaultClient.VAULT_TOKEN, "hello"))
 				//
 				.andRespond(
 						withSuccess().contentType(MediaType.APPLICATION_JSON).body(

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerUnitTests.java
@@ -29,7 +29,7 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultResponseEntity;
 import org.springframework.vault.support.VaultToken;
 
@@ -60,7 +60,7 @@ public class LifecycleAwareSessionManagerUnitTests {
 	private ThreadPoolTaskScheduler taskScheduler;
 
 	@Mock
-	private VaultClient vaultClient;
+	private PreviousVaultClient vaultClient;
 
 	private LifecycleAwareSessionManager sessionManager;
 
@@ -87,7 +87,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 				vaultClient.postForEntity(eq("auth/token/revoke-self"),
 						eq(LoginToken.of("login")), ArgumentMatchers.any(),
 						any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.OK, null, null));
+				new ResponseEntity<Object>(null, HttpStatus.OK, URI
+						.create("/auth/token/revoke-self"), null));
 
 		sessionManager.renewToken();
 		sessionManager.destroy();
@@ -116,7 +117,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 				vaultClient.postForEntity(eq("auth/token/revoke-self"),
 						eq(LoginToken.of("login")), ArgumentMatchers.any(),
 						any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.INTERNAL_SERVER_ERROR, null,
+				new ResponseEntity<Object>(null, HttpStatus.INTERNAL_SERVER_ERROR, URI
+						.create("/auth/token/revoke-self"),
 						null));
 
 		sessionManager.renewToken();
@@ -144,7 +146,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 				vaultClient.postForEntity(eq("auth/token/renew-self"),
 						eq(LoginToken.renewable("login", 5)), ArgumentMatchers.any(),
 						any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.OK, null, null));
+				new ResponseEntity<Object>(null, HttpStatus.OK, URI
+						.create("/auth/token/renew-self"), null));
 
 		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 
@@ -166,7 +169,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 				vaultClient.postForEntity(eq("auth/token/renew-self"),
 						eq(LoginToken.renewable("login", 5)), ArgumentMatchers.any(),
 						any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.OK, null, null));
+				new ResponseEntity<Object>(null, HttpStatus.OK, URI
+						.create("/auth/token/renew-self"), null));
 
 		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 
@@ -203,7 +207,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 				vaultClient.postForEntity(eq("auth/token/renew-self"),
 						eq(LoginToken.renewable("login", 5)), ArgumentMatchers.any(),
 						any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.INTERNAL_SERVER_ERROR, null,
+				new ResponseEntity<Object>(null, HttpStatus.INTERNAL_SERVER_ERROR, URI
+						.create("/auth/token/renew-self"),
 						null));
 
 		ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -235,7 +240,8 @@ public class LifecycleAwareSessionManagerUnitTests {
 		when(
 				vaultClient.postForEntity(anyString(), any(VaultToken.class),
 						ArgumentMatchers.any(), any(Class.class))).thenReturn(
-				new ResponseEntity<Object>(null, HttpStatus.BAD_REQUEST, null, null));
+				new ResponseEntity<Object>(null, HttpStatus.BAD_REQUEST, URI
+						.create("/login"), null));
 
 		sessionManager.getSessionToken();
 

--- a/spring-vault-core/src/test/java/org/springframework/vault/client/VaultClientIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/client/VaultClientIntegrationTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.client;
+
+import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Mark Paluch
+ */
+public class VaultClientIntegrationTests {
+
+	@ClassRule
+	public static MockWebServer mockWebServer = new MockWebServer();
+	VaultEndpoint vaultEndpoint;
+
+	@Before
+	public void before() throws Exception {
+		this.vaultEndpoint = VaultEndpoint.plain(mockWebServer.getHostName(),
+				mockWebServer.getPort());
+	}
+
+	@Test
+	public void withoutBody() throws Exception {
+
+		VaultClient vaultClient = DefaultVaultClient.create(new RestTemplate(),
+				vaultEndpoint);
+
+		mockWebServer.enqueue(new MockResponse().setResponseCode(204).addHeader(
+				HttpHeaders.CONTENT_TYPE, "application/json"));
+
+		VaultResponseEntity<Void> response = vaultClient.get()
+				.uri("/{hello}/{world}", "hello", "world")
+				.header(HttpHeaders.ACCEPT, "text/json").exchange();
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+		RecordedRequest recordedRequest = mockWebServer.takeRequest();
+
+		assertThat(recordedRequest.getBodySize()).isEqualTo(0);
+		assertThat(recordedRequest.getHeader(HttpHeaders.ACCEPT)).isEqualTo("text/json");
+		assertThat(recordedRequest.getPath()).isEqualTo("/v1/hello/world");
+	}
+
+	@Test
+	public void withResponseBody() throws Exception {
+
+		VaultClient vaultClient = DefaultVaultClient.create(new RestTemplate(),
+				vaultEndpoint);
+
+		mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+				.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+				.setBody("{ \"ok\": 1}"));
+
+		VaultResponseEntity<Void> response = vaultClient.get()
+				.uri("/{hello}/{world}", "hello", "world")
+				.header(HttpHeaders.ACCEPT, "text/json").exchange();
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNull();
+	}
+
+	@Test
+	public void withResponseBodyAsMap() throws Exception {
+
+		VaultClient vaultClient = DefaultVaultClient.create(new RestTemplate(),
+				vaultEndpoint);
+
+		mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+				.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+				.setBody("{ \"ok\": 1}"));
+
+		VaultResponseEntity<Map<String, Integer>> response = vaultClient.get()
+				.uri("/{hello}/{world}", "hello", "world")
+				.header(HttpHeaders.ACCEPT, "text/json").exchange(Map.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull().containsEntry("ok", 1);
+	}
+}

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTokenTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTokenTemplateIntegrationTests.java
@@ -46,6 +46,7 @@ public class VaultTokenTemplateIntegrationTests extends IntegrationTestSupport {
 
 	@Autowired
 	private VaultOperations vaultOperations;
+
 	private VaultTokenOperations tokenOperations;
 
 	@Before
@@ -161,8 +162,9 @@ public class VaultTokenTemplateIntegrationTests extends IntegrationTestSupport {
 				.doWithVault(new VaultOperations.ClientCallback<VaultResponseEntity<String>>() {
 					@Override
 					public VaultResponseEntity<String> doWithVault(VaultClient client) {
-						return client.getForEntity("auth/token/lookup-self",
-								tokenResponse.getToken(), String.class);
+
+						return client.get().uri("auth/token/lookup-self")
+								.token(tokenResponse.getToken()).exchange(String.class);
 					}
 				});
 	}

--- a/spring-vault-core/src/test/java/org/springframework/vault/demo/VaultApp.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/demo/VaultApp.java
@@ -16,7 +16,8 @@
 package org.springframework.vault.demo;
 
 import org.springframework.vault.authentication.TokenAuthentication;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.DefaultVaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.core.VaultTemplate;
 import org.springframework.vault.support.VaultResponseSupport;
 
@@ -27,8 +28,9 @@ public class VaultApp {
 
 	public static void main(String[] args) {
 
-		VaultTemplate vaultTemplate = new VaultTemplate(new VaultClient(),
-				new TokenAuthentication("00000000-0000-0000-0000-000000000000"));
+		VaultTemplate vaultTemplate = new VaultTemplate(new PreviousVaultClient(),
+				DefaultVaultClient.create(), new TokenAuthentication(
+						"00000000-0000-0000-0000-000000000000"));
 
 		Secrets secrets = new Secrets();
 		secrets.username = "hello";

--- a/spring-vault-core/src/test/java/org/springframework/vault/util/PrepareVault.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/util/PrepareVault.java
@@ -15,11 +15,9 @@
  */
 package org.springframework.vault.util;
 
-import java.util.Collections;
-
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.vault.client.VaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.core.VaultOperations;
 import org.springframework.vault.core.VaultSysOperations;
 import org.springframework.vault.support.VaultInitializationRequest;
@@ -27,9 +25,9 @@ import org.springframework.vault.support.VaultInitializationResponse;
 import org.springframework.vault.support.VaultMount;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.vault.support.VaultTokenRequest;
-import org.springframework.vault.support.VaultTokenRequest.VaultTokenRequestBuilder;
 import org.springframework.vault.support.VaultTokenResponse;
 import org.springframework.vault.support.VaultUnsealStatus;
+import org.springframework.vault.support.VaultTokenRequest.VaultTokenRequestBuilder;
 
 /**
  * Vault preparation utility class. This class allows preparing Vault for integration
@@ -39,13 +37,13 @@ import org.springframework.vault.support.VaultUnsealStatus;
  */
 public class PrepareVault {
 
-	private final VaultClient vaultClient;
+	private final PreviousVaultClient vaultClient;
 
 	private final VaultOperations vaultOperations;
 
 	private final VaultSysOperations adminOperations;
 
-	public PrepareVault(VaultClient vaultClient, VaultOperations vaultOperations) {
+	public PrepareVault(PreviousVaultClient vaultClient, VaultOperations vaultOperations) {
 
 		this.vaultClient = vaultClient;
 		this.vaultOperations = vaultOperations;
@@ -160,7 +158,7 @@ public class PrepareVault {
 		return vaultOperations;
 	}
 
-	public VaultClient getVaultClient() {
+	public PreviousVaultClient getVaultClient() {
 		return vaultClient;
 	}
 }

--- a/spring-vault-core/src/test/java/org/springframework/vault/util/VaultRule.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/util/VaultRule.java
@@ -24,12 +24,15 @@ import org.junit.rules.ExternalResource;
 
 import org.springframework.util.Assert;
 import org.springframework.vault.authentication.SessionManager;
+import org.springframework.vault.client.DefaultVaultClient;
+import org.springframework.vault.client.PreviousVaultClient;
 import org.springframework.vault.client.VaultClient;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.core.DefaultVaultClientFactory;
 import org.springframework.vault.core.VaultTemplate;
 import org.springframework.vault.support.SslConfiguration;
 import org.springframework.vault.support.VaultToken;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Vault rule to ensure a running and prepared Vault.
@@ -66,16 +69,18 @@ public class VaultRule extends ExternalResource {
 		Assert.notNull(sslConfiguration, "SslConfiguration must not be null");
 		Assert.notNull(vaultEndpoint, "VaultEndpoint must not be null");
 
-		VaultClient vaultClient = new VaultClient(
-				TestRestTemplateFactory.create(sslConfiguration), vaultEndpoint);
+		RestTemplate restTemplate = TestRestTemplateFactory.create(sslConfiguration);
+		PreviousVaultClient previousVaultClient = new PreviousVaultClient(restTemplate,
+				vaultEndpoint);
+		VaultClient vaultClient = DefaultVaultClient.create(restTemplate, vaultEndpoint);
 		DefaultVaultClientFactory clientFactory = new DefaultVaultClientFactory(
-				vaultClient);
+				previousVaultClient, vaultClient);
 
 		VaultTemplate vaultTemplate = new VaultTemplate(clientFactory,
 				new PreparingSessionManager());
 
 		this.token = Settings.token();
-		this.prepareVault = new PrepareVault(vaultClient, vaultTemplate);
+		this.prepareVault = new PrepareVault(previousVaultClient, vaultTemplate);
 		this.vaultEndpoint = vaultEndpoint;
 	}
 

--- a/spring-vault-dependencies/pom.xml
+++ b/spring-vault-dependencies/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.vault</groupId>
 	<artifactId>spring-vault-dependencies</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.ISSUE-49-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>spring-vault-dependencies</name>

--- a/spring-vault-distribution/pom.xml
+++ b/spring-vault-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.vault</groupId>
 		<artifactId>spring-vault-parent</artifactId>
-		<version>1.0.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0.ISSUE-49-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
**Do not merge.**

Rename VaultClient to PreviousVaultClient. Introduce `VaultClient` and `VaultClientRequest` interfaces. Add default implementations with `DefaultVaultClient` and `DefaultVaultClientRequest`. Introduce `VaultRequestBody` as body provider.

Usage:

```java
VaultResponseEntity<String> response = vaultClient.get()
				.uri("/{hello}/{world}", "hello", "world")
				.header("X-Vault-Token", "…")
				.exchange(String.class);

VaultResponseEntity<Void> response = vaultClient.get()
				.uri("/{hello}/{world}", "hello", "world")
				.header("X-Vault-Token", "…")
				.body(VaultRequestBody.just("{ \"ok\": 1}"))
				.exchange();

VaultResponseEntity<Void> response = vaultClient.get()
				.uri("/example")
				.exchange();
```

`VaultClient` defines a builder-style API to build requests with exposing only contextual API for the current build step