### PR TITLE
Allow to set lease mode from property

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/domain/RequestedSecret.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/domain/RequestedSecret.java
@@ -66,6 +66,20 @@ public class RequestedSecret {
 	}
 
 	/**
+	 * Create a rotating or renewable {@link RequestedSecret} at {@code path}. A lease associated with
+	 * this secret will be renewed if the lease is qualified for renewal. Once the lease
+	 * expires, a new secret with a new lease is obtained if mode is ROTATE, otherwize the lease is no
+	 * longer valid after expiry.
+	 *
+	 * @param mode must not be {@literal null}
+	 * @param path must not be {@literal null} or empty, must not start with a slash.
+	 * @return the rotating {@link RequestedSecret}.
+	 */
+	public static RequestedSecret buildFromMode(Mode mode, String path) {
+		return mode.buildRequestedSecret(path);
+	}
+
+	/**
 	 * @return the Vault path of the requested secret.
 	 */
 	public String getPath() {
@@ -95,12 +109,24 @@ public class RequestedSecret {
 		/**
 		 * Renew lease of the requested secret until secret expires its max lease time.
 		 */
-		RENEW,
+		RENEW {
+			@Override
+			public RequestedSecret buildRequestedSecret(String path) {
+				return renewable(path);
+			}
+		},
 
 		/**
 		 * Renew lease of the requested secret. Obtains new secret along a new lease once
 		 * the previous lease expires its max lease time.
 		 */
-		ROTATE;
+		ROTATE {
+			@Override
+			public RequestedSecret buildRequestedSecret(String path) {
+				return rotating(path);
+			}
+		};
+
+		abstract RequestedSecret buildRequestedSecret(String path);
 	}
 }

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/lease/domain/RequestedSecretTest.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/lease/domain/RequestedSecretTest.java
@@ -1,0 +1,24 @@
+package org.springframework.vault.core.lease.domain;
+
+import org.junit.Test;
+import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestedSecretTest {
+
+    @Test
+    public void should_build_rotating_requested_secret() {
+        RequestedSecret requestedSecret = RequestedSecret.buildFromMode(Mode.ROTATE, "my/path");
+
+        assertThat(requestedSecret.getMode()).isEqualTo(Mode.ROTATE);
+    }
+
+    @Test
+    public void should_build_renewal_requested_secret() {
+        RequestedSecret requestedSecret = RequestedSecret.buildFromMode(Mode.RENEW, "my/path");
+
+        assertThat(requestedSecret.getMode()).isEqualTo(Mode.RENEW);
+    }
+
+}


### PR DESCRIPTION
This change gives the user the opportunity to create a requested secret from a mode that is injected from somewhere, like configuration file for instance (see [an example](https://github.com/spring-cloud/spring-cloud-vault-config/pull/90)). It also avoids the user to check the mode before creating it each time.