### PR TITLE
Allow health check to pass `standbyok` parameter.

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
@@ -127,11 +127,25 @@ public interface VaultSysOperations {
 	void authUnmount(String path) throws VaultException;
 
 	/**
-	 * Return the health status of Vault.
+	 * Return the health status of Vault. Implementations should ensure this is
+	 * functionally equivalent to {@link #health(boolean) health(false)}.
 	 *
 	 * @return the {@link VaultHealth}.
 	 * @see <a href="https://www.vaultproject.io/docs/http/sys-health.html">GET
 	 * /sys/health</a>
 	 */
 	VaultHealth health() throws VaultException;
+
+	/**
+	 * Return the health status of Vault.
+	 *
+	 * @param standbyOk when {@literal true}, requests to a standby Vault server in HA
+	 * configuration will return the active response code instead of the standby response
+	 * code.
+	 *
+	 * @return the {@link VaultHealth}.
+	 * @see <a href="https://www.vaultproject.io/docs/http/sys-health.html">GET
+	 * /sys/health</a>
+	 */
+	VaultHealth health(boolean standbyOk) throws VaultException;
 }


### PR DESCRIPTION
Beginning with Vault 0.2.0, the `/sys/health` endpoint for Vault allows an optional request parameter, `standbyok`, which, when set to `true` (default is `false`) will cause the health check to return a 200 status instead of a 429 status for a standby Vault node. It would be nice if the health check in Spring Vault supported this feature.

See https://www.vaultproject.io/api/system/health.html

Refs spring-cloud/spring-cloud-vault#112