### PR TITLE
Add the ability to use response wrapping for AppRole secretId responses

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthenticationOptions.java
@@ -65,15 +65,22 @@ public class AppRoleAuthenticationOptions {
 	@Nullable
 	private final VaultToken initialToken;
 
+	/**
+	 * Token for unwrapping the secretId response
+	 */
+	@Nullable
+	private final VaultToken unwrappingToken;
+
 	private AppRoleAuthenticationOptions(String path, @Nullable String roleId,
 			@Nullable String secretId, @Nullable String appRole,
-			@Nullable VaultToken initialToken) {
+			@Nullable VaultToken initialToken, @Nullable VaultToken unwrappingToken) {
 
 		this.path = path;
 		this.roleId = roleId;
 		this.secretId = secretId;
 		this.appRole = appRole;
 		this.initialToken = initialToken;
+		this.unwrappingToken = unwrappingToken;
 	}
 
 	/**
@@ -125,6 +132,15 @@ public class AppRoleAuthenticationOptions {
 	}
 
 	/**
+	 * @return the token used to unwrap the roleId response.
+	 * @since 2.0
+	 */
+	@Nullable
+	public VaultToken getUnwrappingToken() {
+		return unwrappingToken;
+	}
+
+	/**
 	 * Builder for {@link AppRoleAuthenticationOptions}.
 	 */
 	public static class AppRoleAuthenticationOptionsBuilder {
@@ -140,6 +156,8 @@ public class AppRoleAuthenticationOptions {
 		private String appRole;
 
 		private VaultToken initialToken;
+
+		private VaultToken unwrappingToken;
 
 		AppRoleAuthenticationOptionsBuilder() {
 		}
@@ -218,6 +236,21 @@ public class AppRoleAuthenticationOptions {
 		}
 
 		/**
+		 * Configure a {@code unwrappingToken}.
+		 *
+		 * @param unwrappingToken must not be empty or {@literal null}.
+		 * @return {@code this} {@link AppRoleAuthenticationOptionsBuilder}.
+		 * @since 2.0
+		 */
+		public AppRoleAuthenticationOptionsBuilder unwrappingToken(VaultToken unwrappingToken) {
+
+			Assert.notNull(unwrappingToken, "UnwrappingToken must not be null");
+
+			this.unwrappingToken = unwrappingToken;
+			return this;
+		}
+
+		/**
 		 * Build a new {@link AppRoleAuthenticationOptions} instance. Requires
 		 * {@link #roleId(String)} for push mode or {@link #appRole(String)} and
 		 * {@link #initialToken(VaultToken)} for pull mode to be configured.
@@ -247,7 +280,7 @@ public class AppRoleAuthenticationOptions {
 			}
 
 			return new AppRoleAuthenticationOptions(path, roleId, secretId, appRole,
-					initialToken);
+					initialToken, unwrappingToken);
 		}
 	}
 }

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppRoleAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AppRoleAuthenticationUnitTests.java
@@ -27,6 +27,7 @@ import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultClients;
 import org.springframework.vault.client.VaultClients.PrefixAwareUriTemplateHandler;
 import org.springframework.vault.support.VaultToken;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  *
  * @author Mark Paluch
  * @author Vincent Le Nair
+ * @author Christophe Tafani-Dereeper
  */
 public class AppRoleAuthenticationUnitTests {
 
@@ -173,5 +175,57 @@ public class AppRoleAuthenticationUnitTests {
 				.andRespond(withServerError());
 
 		new AppRoleAuthentication(options, restTemplate).login();
+	}
+
+	@Test
+	public void loginShouldUnwrapSecretIdResponse() {
+		AppRoleAuthenticationOptions options = AppRoleAuthenticationOptions.builder()
+				.roleId("my_role_id")
+				.unwrappingToken(VaultToken.of("unwrapping_token"))
+				.build();
+
+		// Expect a first request to unwrap the response
+		mockRest.expect(requestTo("/sys/wrapping/unwrap"))
+				.andExpect(header("X-Vault-Token", "unwrapping_token"))
+				.andExpect(method(HttpMethod.POST))
+				.andRespond(
+						withSuccess().contentType(MediaType.APPLICATION_JSON).body("{" +
+								"  \"request_id\": \"aad6a19b-a42b-b750-cafb-51087662f53e\"," +
+								"  \"lease_id\": \"\"," +
+								"  \"renewable\": false," +
+								"  \"lease_duration\": 0," +
+								"  \"data\": {" +
+								"    \"secret_id\": \"my_secret_id\"," +
+								"    \"secret_id_accessor\": \"my_secret_id_accessor\"" +
+								"  }," +
+								"  \"wrap_info\": null," +
+								"  \"warnings\": null," +
+								"  \"auth\": null" +
+								"}"
+						)
+				);
+
+		// Also expect a second request to retrieve a token
+		mockRest.expect(requestTo("/auth/approle/login"))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(jsonPath("$.role_id").value("my_role_id"))
+				.andExpect(jsonPath("$.secret_id").value("my_secret_id"))
+				.andRespond(
+						withSuccess()
+						.contentType(MediaType.APPLICATION_JSON)
+						.body("{"
+								+ "\"auth\":{\"client_token\":\"my-token\", \"lease_duration\": 10, \"renewable\": true}"
+								+ "}")
+				);
+
+		AppRoleAuthentication auth = new AppRoleAuthentication(options, restTemplate);
+
+		VaultToken login = auth.login();
+
+		assertThat(login).isInstanceOf(LoginToken.class);
+		assertThat(login.getToken()).isEqualTo("my-token");
+		assertThat(((LoginToken) login).getLeaseDuration()).isEqualTo(
+				Duration.ofSeconds(10));
+		assertThat(((LoginToken) login).isRenewable()).isTrue();
 	}
 }


### PR DESCRIPTION
Related to #164.

This is a first shot, let me know what you think.

### Sample use-case

- At deployment time, a configuration management tool / deployment tool generates a wrapped secret id response using something like `vault write -wrap-ttl=10m -f auth/approle/role/some_role/secret-id`. 
- The tool injects (environment variable, file, whatever) the unwrapping token in the application
- The application hits `sys/wrapping/unwrap` with the unwrapping token to retrieve its AppRole secret ID. If the call fails, the application would typically raise an alert because it can mean two things:
    - the application took to much time to start, and the TTL of the unwrapping token expired
    - the unwrapping token was compromised and used by a malicious party to retrieve information it shouldn't have had access to