### PR TITLE
Initial cut of revisions to Exception Hierarchy

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
@@ -114,7 +114,7 @@ public class AppIdAuthentication implements ClientAuthentication,
 		}
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format("Cannot login using app-id: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppIdAuthentication.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.util.Assert;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -112,8 +113,8 @@ public class AppIdAuthentication implements ClientAuthentication,
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format("Cannot login using app-id: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+			throw new VaultHttpException(String.format("Cannot login using app-id: %s",
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
@@ -228,7 +228,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 		}
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format("Cannot login using AppRole: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 
@@ -253,7 +253,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			catch (HttpStatusCodeException e) {
 				throw new VaultHttpException(String.format(
 						"Cannot get Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+						VaultResponses.getError(e.getResponseBodyAsString())), e);
 			}
 		}
 
@@ -276,7 +276,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			catch (HttpStatusCodeException e) {
 				throw new VaultHttpException(String.format(
 						"Cannot unwrap Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+						VaultResponses.getError(e.getResponseBodyAsString())), e);
 			}
 		}
 
@@ -302,7 +302,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			catch (HttpStatusCodeException e) {
 				throw new VaultHttpException(String.format(
 						"Cannot get Secret id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+						VaultResponses.getError(e.getResponseBodyAsString())), e);
 			}
 		}
 
@@ -325,7 +325,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			catch (HttpStatusCodeException e) {
 				throw new VaultHttpException(String.format(
 						"Cannot unwrap Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+						VaultResponses.getError(e.getResponseBodyAsString())), e);
 			}
 		}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AppRoleAuthentication.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.vault.authentication;
 
+import static org.springframework.vault.authentication.AuthenticationSteps.HttpRequestBuilder.get;
+import static org.springframework.vault.authentication.AuthenticationSteps.HttpRequestBuilder.post;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -37,13 +39,12 @@ import org.springframework.vault.authentication.AppRoleTokens.Pull;
 import org.springframework.vault.authentication.AppRoleTokens.Wrapped;
 import org.springframework.vault.authentication.AuthenticationSteps.Node;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultClientException;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestOperations;
-
-import static org.springframework.vault.authentication.AuthenticationSteps.HttpRequestBuilder.get;
-import static org.springframework.vault.authentication.AuthenticationSteps.HttpRequestBuilder.post;
 
 /**
  * AppRole implementation of {@link ClientAuthentication}. RoleId and SecretId (optional)
@@ -105,7 +106,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 		if ((roleId instanceof Wrapped || roleId instanceof Pull)
 				&& (secretId instanceof Wrapped || secretId instanceof Pull)) {
 
-			throw new IllegalArgumentException(
+			throw new VaultClientException(
 					"RoleId and SecretId are both configured to obtain their values from initial Vault request. AuthenticationSteps supports currently only fetching of a single element.");
 		}
 
@@ -181,7 +182,7 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			});
 		}
 
-		throw new IllegalArgumentException(String.format(
+		throw new VaultClientException(String.format(
 				"Provided RoleId/SecretId setup not supported. RoleId: %s, SecretId: %s",
 				roleId, secretId));
 	}
@@ -226,8 +227,8 @@ public class AppRoleAuthentication implements ClientAuthentication,
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format("Cannot login using AppRole: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+			throw new VaultHttpException(String.format("Cannot login using AppRole: %s",
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 
@@ -250,9 +251,9 @@ public class AppRoleAuthentication implements ClientAuthentication,
 				return (String) entity.getBody().getRequiredData().get("role_id");
 			}
 			catch (HttpStatusCodeException e) {
-				throw new VaultException(String.format(
+				throw new VaultHttpException(String.format(
 						"Cannot get Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())));
+						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 			}
 		}
 
@@ -273,13 +274,13 @@ public class AppRoleAuthentication implements ClientAuthentication,
 				return (String) response.getRequiredData().get("role_id");
 			}
 			catch (HttpStatusCodeException e) {
-				throw new VaultException(String.format(
+				throw new VaultHttpException(String.format(
 						"Cannot unwrap Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())));
+						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 			}
 		}
 
-		throw new IllegalArgumentException("Unknown RoleId configuration: " + roleId);
+		throw new VaultClientException("Unknown RoleId configuration: " + roleId);
 	}
 
 	private String getSecretId(SecretId secretId) {
@@ -299,9 +300,9 @@ public class AppRoleAuthentication implements ClientAuthentication,
 				return (String) response.getRequiredData().get("secret_id");
 			}
 			catch (HttpStatusCodeException e) {
-				throw new VaultException(String.format(
+				throw new VaultHttpException(String.format(
 						"Cannot get Secret id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())));
+						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 			}
 		}
 
@@ -322,13 +323,13 @@ public class AppRoleAuthentication implements ClientAuthentication,
 				return (String) response.getRequiredData().get("secret_id");
 			}
 			catch (HttpStatusCodeException e) {
-				throw new VaultException(String.format(
+				throw new VaultHttpException(String.format(
 						"Cannot unwrap Role id using AppRole: %s",
-						VaultResponses.getError(e.getResponseBodyAsString())));
+						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 			}
 		}
 
-		throw new IllegalArgumentException("Unknown SecretId configuration: " + secretId);
+		throw new VaultClientException("Unknown SecretId configuration: " + secretId);
 	}
 
 	private static HttpHeaders createHttpHeaders(VaultToken token) {

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsExecutor.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsExecutor.java
@@ -108,7 +108,7 @@ public class AuthenticationStepsExecutor implements ClientAuthentication {
 				throw new VaultHttpException(String.format(
 						"HTTP request %s in state %s failed with Status %s and body %s",
 						o, state, e.getStatusCode(),
-						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+						VaultResponses.getError(e.getResponseBodyAsString())), e);
 			}
 			catch (VaultException e) {
 				throw e;

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsExecutor.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsExecutor.java
@@ -30,6 +30,7 @@ import org.springframework.vault.authentication.AuthenticationSteps.Node;
 import org.springframework.vault.authentication.AuthenticationSteps.OnNextStep;
 import org.springframework.vault.authentication.AuthenticationSteps.SupplierStep;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -104,10 +105,13 @@ public class AuthenticationStepsExecutor implements ClientAuthentication {
 				}
 			}
 			catch (HttpStatusCodeException e) {
-				throw new VaultException(String.format(
+				throw new VaultHttpException(String.format(
 						"HTTP request %s in state %s failed with Status %s and body %s",
 						o, state, e.getStatusCode(),
-						VaultResponses.getError(e.getResponseBodyAsString())));
+						VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+			}
+			catch (VaultException e) {
+				throw e;
 			}
 			catch (RuntimeException e) {
 				throw new VaultException(String.format(
@@ -126,7 +130,7 @@ public class AuthenticationStepsExecutor implements ClientAuthentication {
 			return LoginTokenUtil.from(response.getAuth());
 		}
 
-		throw new IllegalStateException(String.format(
+		throw new VaultException(String.format(
 				"Cannot retrieve VaultToken from authentication chain. Got instead %s",
 				state));
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsOperator.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationStepsOperator.java
@@ -31,6 +31,8 @@ import org.springframework.vault.authentication.AuthenticationSteps.MapStep;
 import org.springframework.vault.authentication.AuthenticationSteps.Node;
 import org.springframework.vault.authentication.AuthenticationSteps.OnNextStep;
 import org.springframework.vault.authentication.AuthenticationSteps.SupplierStep;
+import org.springframework.vault.exceptions.VaultClientException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -127,13 +129,13 @@ public class AuthenticationStepsOperator implements VaultTokenSupplier {
 						return LoginTokenUtil.from(response.getAuth());
 					}
 
-					throw new IllegalStateException(
+					throw new VaultException(
 							String.format(
 									"Cannot retrieve VaultToken from authentication chain. Got instead %s",
 									stateObject));
 				})
 				.onErrorMap(
-						t -> new VaultException(
+						t -> t instanceof VaultException ? t : new VaultException(
 								"Cannot retrieve VaultToken from authentication chain", t));
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
@@ -187,7 +187,7 @@ public class AwsEc2Authentication implements ClientAuthentication,
 		}
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format("Cannot login using AWS-EC2: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 
@@ -217,7 +217,7 @@ public class AwsEc2Authentication implements ClientAuthentication,
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format(
 					"Cannot obtain Identity Document from %s",
-					options.getIdentityDocumentUri()), e, e.getStatusCode());
+					options.getIdentityDocumentUri()), e);
 		}
 		catch (RestClientException e) {
 			throw new VaultRemoteException(String.format(

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2Authentication.java
@@ -29,6 +29,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.authentication.AuthenticationSteps.HttpRequestBuilder;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -184,8 +186,8 @@ public class AwsEc2Authentication implements ClientAuthentication,
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format("Cannot login using AWS-EC2: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+			throw new VaultHttpException(String.format("Cannot login using AWS-EC2: %s",
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 
@@ -212,8 +214,13 @@ public class AwsEc2Authentication implements ClientAuthentication,
 
 			return login;
 		}
+		catch (HttpStatusCodeException e) {
+			throw new VaultHttpException(String.format(
+					"Cannot obtain Identity Document from %s",
+					options.getIdentityDocumentUri()), e, e.getStatusCode());
+		}
 		catch (RestClientException e) {
-			throw new VaultException(String.format(
+			throw new VaultRemoteException(String.format(
 					"Cannot obtain Identity Document from %s",
 					options.getIdentityDocumentUri()), e);
 		}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsIamAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsIamAuthentication.java
@@ -138,7 +138,7 @@ public class AwsIamAuthentication implements ClientAuthentication {
 		}
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format("Cannot login using AWS-IAM: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsIamAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsIamAuthentication.java
@@ -37,6 +37,8 @@ import org.springframework.util.Base64Utils;
 import org.springframework.util.StringUtils;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultClientException;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -135,8 +137,8 @@ public class AwsIamAuthentication implements ClientAuthentication {
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format("Cannot login using AWS-IAM: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+			throw new VaultHttpException(String.format("Cannot login using AWS-IAM: %s",
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 
@@ -194,7 +196,7 @@ public class AwsIamAuthentication implements ClientAuthentication {
 			return OBJECT_MAPPER.writeValueAsString(map);
 		}
 		catch (JsonProcessingException e) {
-			throw new IllegalStateException("Cannot serialize headers to JSON", e);
+			throw new VaultClientException("Cannot serialize headers to JSON", e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
@@ -91,7 +91,7 @@ public class ClientCertificateAuthentication implements ClientAuthentication,
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format(
 					"Cannot login using TLS certificates: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ClientCertificateAuthentication.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.util.Assert;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -88,9 +89,9 @@ public class ClientCertificateAuthentication implements ClientAuthentication,
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format(
+			throw new VaultHttpException(String.format(
 					"Cannot login using TLS certificates: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
@@ -227,7 +227,7 @@ public class CubbyholeAuthentication implements ClientAuthentication,
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format(
 					"Cannot retrieve Token from Cubbyhole: %s %s", e.getStatusCode(),
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/CubbyholeAuthentication.java
@@ -29,6 +29,8 @@ import org.springframework.vault.VaultException;
 import org.springframework.vault.authentication.AuthenticationSteps.HttpRequest;
 import org.springframework.vault.client.VaultHttpHeaders;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultResponseSupport;
 import org.springframework.vault.support.VaultToken;
@@ -223,9 +225,9 @@ public class CubbyholeAuthentication implements ClientAuthentication,
 			return entity.getBody().getData();
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format(
+			throw new VaultHttpException(String.format(
 					"Cannot retrieve Token from Cubbyhole: %s %s", e.getStatusCode(),
-					VaultResponses.getError(e.getResponseBodyAsString())));
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 
@@ -263,7 +265,7 @@ public class CubbyholeAuthentication implements ClientAuthentication,
 		}
 
 		if (data == null || data.isEmpty()) {
-			throw new VaultException(
+			throw new VaultRemoteException(
 					String.format(
 							"Cannot retrieve Token from Cubbyhole: Response at %s does not contain a token",
 							options.getPath()));
@@ -274,7 +276,7 @@ public class CubbyholeAuthentication implements ClientAuthentication,
 			return VaultToken.of(token);
 		}
 
-		throw new VaultException(
+		throw new VaultRemoteException(
 				String.format(
 						"Cannot retrieve Token from Cubbyhole: Response at %s does not contain an unique token",
 						options.getPath()));

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/IpAddressUserId.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/IpAddressUserId.java
@@ -19,6 +19,8 @@ package org.springframework.vault.authentication;
 import java.io.IOException;
 import java.net.InetAddress;
 
+import org.springframework.vault.exceptions.VaultClientException;
+
 /**
  * Mechanism to generate a SHA-256 hashed and hex-encoded representation of the IP
  * address. Can be calculated with {@code echo -n 192.168.99.1 | sha256sum}.
@@ -34,7 +36,7 @@ public class IpAddressUserId implements AppIdUserIdMechanism {
 			return Sha256.toSha256(InetAddress.getLocalHost().getHostAddress());
 		}
 		catch (IOException e) {
-			throw new IllegalStateException(e);
+			throw new VaultClientException("While creating userId", e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesAuthentication.java
@@ -107,7 +107,7 @@ public class KubernetesAuthentication implements ClientAuthentication,
 		}
 		catch (HttpStatusCodeException e) {
 			throw new VaultHttpException(String.format("Cannot login using kubernetes: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesAuthentication.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.util.Assert;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -105,8 +106,8 @@ public class KubernetesAuthentication implements ClientAuthentication,
 			return LoginTokenUtil.from(response.getAuth());
 		}
 		catch (HttpStatusCodeException e) {
-			throw new VaultException(String.format("Cannot login using kubernetes: %s",
-					VaultResponses.getError(e.getResponseBodyAsString())));
+			throw new VaultHttpException(String.format("Cannot login using kubernetes: %s",
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesServiceAccountTokenFile.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/KubernetesServiceAccountTokenFile.java
@@ -25,6 +25,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 import org.springframework.vault.VaultException;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Mechanism to retrieve a Kubernetes service account token.
@@ -96,7 +97,7 @@ public class KubernetesServiceAccountTokenFile implements KubernetesJwtSupplier 
 			this.token = readToken(resource);
 		}
 		catch (IOException e) {
-			throw new VaultException(String.format(
+			throw new VaultClientException(String.format(
 					"Kube JWT token retrieval from %s failed", resource), e);
 		}
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
@@ -223,7 +223,7 @@ public class LifecycleAwareSessionManager extends LifecycleAwareSessionManagerSu
 				return false;
 			}
 
-			throw new VaultHttpException(VaultResponses.getError(e.getResponseBodyAsString()), e.getStatusCode());
+			throw new VaultHttpException(VaultResponses.getError(e.getResponseBodyAsString()), e);
 		}
 		catch (RestClientException e) {
 			throw new VaultRemoteException("Cannot refresh token");

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
@@ -30,6 +30,8 @@ import org.springframework.util.ClassUtils;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultHttpHeaders;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.client.HttpStatusCodeException;
@@ -221,10 +223,10 @@ public class LifecycleAwareSessionManager extends LifecycleAwareSessionManagerSu
 				return false;
 			}
 
-			throw new VaultException(VaultResponses.getError(e.getResponseBodyAsString()));
+			throw new VaultHttpException(VaultResponses.getError(e.getResponseBodyAsString()), e.getStatusCode());
 		}
 		catch (RestClientException e) {
-			throw new VaultException("Cannot refresh token", e);
+			throw new VaultRemoteException("Cannot refresh token");
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoginTokenAdapter.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoginTokenAdapter.java
@@ -104,7 +104,7 @@ public class LoginTokenAdapter implements ClientAuthentication {
 		catch (HttpStatusCodeException e) {
 			throw new VaultTokenLookupException(String.format(
 					"Token self-lookup failed: %s %s", e.getStatusCode(),
-					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+					VaultResponses.getError(e.getResponseBodyAsString())), e);
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoginTokenAdapter.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoginTokenAdapter.java
@@ -104,7 +104,7 @@ public class LoginTokenAdapter implements ClientAuthentication {
 		catch (HttpStatusCodeException e) {
 			throw new VaultTokenLookupException(String.format(
 					"Token self-lookup failed: %s %s", e.getStatusCode(),
-					VaultResponses.getError(e.getResponseBodyAsString())));
+					VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/MacAddressUserId.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/MacAddressUserId.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Mechanism to generate a UserId based on the Mac address. {@link MacAddressUserId}
@@ -128,7 +129,7 @@ public class MacAddressUserId implements AppIdUserIdMechanism {
 							"Cannot determine NetworkInterface"));
 		}
 		catch (IOException e) {
-			throw new IllegalStateException(e);
+			throw new VaultClientException("While creating userId", e);
 		}
 
 	}
@@ -172,7 +173,7 @@ public class MacAddressUserId implements AppIdUserIdMechanism {
 			return Optional.ofNullable(it.getHardwareAddress());
 		}
 		catch (SocketException e) {
-			throw new IllegalStateException(String
+			throw new VaultClientException(String
 					.format("Cannot determine hardware address for %s", it.getName()));
 		}
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
@@ -225,7 +225,7 @@ public class ReactiveLifecycleAwareSessionManager extends
 							}
 
 							return Mono.error(new VaultHttpException(VaultResponses
-									.getError(e.getResponseBodyAsString()), e.getStatusCode()));
+									.getError(e.getResponseBodyAsString()), e));
 						})
 				.onErrorMap(WebClientException.class,
 						e -> new VaultRemoteException("Cannot refresh token", e))
@@ -411,7 +411,7 @@ public class ReactiveLifecycleAwareSessionManager extends
 						e -> {
 							return new VaultTokenLookupException(String.format(
 									"Token self-lookup failed: %s %s", e.getStatusCode(),
-									VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
+									VaultResponses.getError(e.getResponseBodyAsString())), e);
 						});
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
@@ -20,10 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Mono;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
@@ -31,11 +27,17 @@ import org.springframework.util.ClassUtils;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultHttpHeaders;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultHttpException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 
 /**
  * Reactive implementation of Lifecycle-aware {@link ReactiveSessionManager session
@@ -222,11 +224,11 @@ public class ReactiveLifecycleAwareSessionManager extends
 								return EMPTY;
 							}
 
-							return Mono.error(new VaultException(VaultResponses
-									.getError(e.getResponseBodyAsString())));
+							return Mono.error(new VaultHttpException(VaultResponses
+									.getError(e.getResponseBodyAsString()), e.getStatusCode()));
 						})
 				.onErrorMap(WebClientException.class,
-						e -> new VaultException("Cannot refresh token", e))
+						e -> new VaultRemoteException("Cannot refresh token", e))
 				.map(TokenWrapper::getToken);
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
@@ -409,7 +409,7 @@ public class ReactiveLifecycleAwareSessionManager extends
 						e -> {
 							return new VaultTokenLookupException(String.format(
 									"Token self-lookup failed: %s %s", e.getStatusCode(),
-									VaultResponses.getError(e.getResponseBodyAsString())));
+									VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode());
 						});
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/VaultTokenLookupException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/VaultTokenLookupException.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.vault.authentication;
 
-import org.springframework.vault.VaultException;
+import org.springframework.http.HttpStatus;
+import org.springframework.vault.exceptions.VaultHttpException;
 
 /**
  * Exception thrown if a token self-lookup fails via {@code auth/token/lookup-self}.
@@ -23,14 +24,14 @@ import org.springframework.vault.VaultException;
  * @author Mark Paluch
  * @since 2.0
  */
-public class VaultTokenLookupException extends VaultException {
+public class VaultTokenLookupException extends VaultHttpException {
 
 	/**
 	 * Create a {@code VaultException} with the specified detail message.
 	 *
 	 * @param msg the detail message.
 	 */
-	public VaultTokenLookupException(String msg) {
-		super(msg);
+	public VaultTokenLookupException(String msg, HttpStatus httpStatus) {
+		super(msg, httpStatus);
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/VaultTokenLookupException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/VaultTokenLookupException.java
@@ -17,6 +17,8 @@ package org.springframework.vault.authentication;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.vault.exceptions.VaultHttpException;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * Exception thrown if a token self-lookup fails via {@code auth/token/lookup-self}.
@@ -31,7 +33,11 @@ public class VaultTokenLookupException extends VaultHttpException {
 	 *
 	 * @param msg the detail message.
 	 */
-	public VaultTokenLookupException(String msg, HttpStatus httpStatus) {
+	public VaultTokenLookupException(String msg, HttpStatusCodeException httpStatus) {
 		super(msg, httpStatus);
+	}
+
+	public VaultTokenLookupException(final String msg, final WebClientResponseException e) {
+		super(msg, e);
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultEndpoint.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultEndpoint.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import lombok.EqualsAndHashCode;
 
 import org.springframework.util.Assert;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Value object that defines Vault connection coordinates.
@@ -92,7 +93,7 @@ public class VaultEndpoint implements Serializable {
 					: uri.getPort());
 		}
 		catch (MalformedURLException e) {
-			throw new IllegalArgumentException(String.format(
+			throw new VaultClientException(String.format(
 					"Can't retrieve default port from %s", uri), e);
 		}
 		vaultEndpoint.setScheme(uri.getScheme());

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponses.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponses.java
@@ -33,6 +33,8 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.vault.VaultException;
+import org.springframework.vault.exceptions.VaultClientException;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponseSupport;
 import org.springframework.web.client.HttpStatusCodeException;
 
@@ -60,11 +62,11 @@ public abstract class VaultResponses {
 		String message = VaultResponses.getError(e.getResponseBodyAsString());
 
 		if (StringUtils.hasText(message)) {
-			return new VaultException(String.format("Status %s: %s", e.getStatusCode(),
-					message));
+			return new VaultHttpException(String.format("Status %s: %s", e.getStatusCode(),
+					message), e.getStatusCode());
 		}
 
-		return new VaultException(String.format("Status %s", e.getStatusCode()));
+		return new VaultHttpException(String.format("Status %s", e.getStatusCode()), e.getStatusCode());
 	}
 
 	/**
@@ -86,11 +88,11 @@ public abstract class VaultResponses {
 			String message) {
 
 		if (StringUtils.hasText(message)) {
-			return new VaultException(String.format("Status %s %s: %s", statusCode, path,
-					message));
+			return new VaultHttpException(String.format("Status %s %s: %s", statusCode, path,
+					message), statusCode);
 		}
 
-		return new VaultException(String.format("Status %s %s", statusCode, path));
+		return new VaultHttpException(String.format("Status %s %s", statusCode, path), statusCode);
 	}
 
 	/**
@@ -188,7 +190,7 @@ public abstract class VaultResponses {
 			});
 		}
 		catch (IOException e) {
-			throw new IllegalStateException(e);
+			throw new VaultClientException("While mapping object", e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponses.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultResponses.java
@@ -63,10 +63,10 @@ public abstract class VaultResponses {
 
 		if (StringUtils.hasText(message)) {
 			return new VaultHttpException(String.format("Status %s: %s", e.getStatusCode(),
-					message), e.getStatusCode());
+					message), e);
 		}
 
-		return new VaultHttpException(String.format("Status %s", e.getStatusCode()), e.getStatusCode());
+		return new VaultHttpException(String.format("Status %s", e.getStatusCode()), e);
 	}
 
 	/**
@@ -80,19 +80,30 @@ public abstract class VaultResponses {
 
 		Assert.notNull(e, "HttpStatusCodeException must not be null");
 
-		return buildException(e.getStatusCode(), path,
+		return buildException(e, path,
 				VaultResponses.getError(e.getResponseBodyAsString()));
 	}
 
-	public static VaultException buildException(HttpStatus statusCode, String path,
+	public static VaultException buildException(HttpStatusCodeException e, String path,
 			String message) {
 
 		if (StringUtils.hasText(message)) {
-			return new VaultHttpException(String.format("Status %s %s: %s", statusCode, path,
-					message), statusCode);
+			return new VaultHttpException(String.format("Status %s %s: %s", e.getStatusCode(), path,
+					message), e);
 		}
 
-		return new VaultHttpException(String.format("Status %s %s", statusCode, path), statusCode);
+		return new VaultHttpException(String.format("Status %s %s", e.getStatusCode(), path), e);
+	}
+
+	public static VaultException buildException(HttpStatus status, String path,
+												String message) {
+
+		if (StringUtils.hasText(message)) {
+			return new VaultHttpException(String.format("Status %s %s: %s",status, path,
+					message), status);
+		}
+
+		return new VaultHttpException(String.format("Status %s %s",status, path), status);
 	}
 
 	/**

--- a/spring-vault-core/src/main/java/org/springframework/vault/config/AbstractReactiveVaultConfiguration.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/AbstractReactiveVaultConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.authentication.VaultTokenSupplier;
 import org.springframework.vault.client.ReactiveVaultClients;
 import org.springframework.vault.core.ReactiveVaultTemplate;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.ClientOptions;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -137,7 +138,7 @@ public abstract class AbstractReactiveVaultConfiguration extends
 			return CachingVaultTokenSupplier.of(stepsOperator);
 		}
 
-		throw new IllegalStateException(
+		throw new VaultClientException(
 				String.format(
 						"Cannot construct VaultTokenSupplier from %s. "
 								+ "ClientAuthentication must implement AuthenticationStepsFactory or be TokenAuthentication",

--- a/spring-vault-core/src/main/java/org/springframework/vault/config/ClientHttpConnectorFactory.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/ClientHttpConnectorFactory.java
@@ -25,6 +25,7 @@ import reactor.ipc.netty.resources.PoolResources;
 
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.ClientOptions;
 import org.springframework.vault.support.SslConfiguration;
 
@@ -87,7 +88,7 @@ public class ClientHttpConnectorFactory {
 			}
 		}
 		catch (GeneralSecurityException | IOException e) {
-			throw new IllegalStateException(e);
+			throw new VaultClientException("While configuring ssl", e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/config/ClientHttpRequestFactoryFactory.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/ClientHttpRequestFactoryFactory.java
@@ -51,6 +51,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.ClientOptions;
 import org.springframework.vault.support.SslConfiguration;
 import org.springframework.vault.support.SslConfiguration.KeyStoreConfiguration;
@@ -108,11 +109,8 @@ public class ClientHttpRequestFactoryFactory {
 				return Netty.usingNetty(options, sslConfiguration);
 			}
 		}
-		catch (GeneralSecurityException e) {
-			throw new IllegalStateException(e);
-		}
-		catch (IOException e) {
-			throw new IllegalStateException(e);
+		catch (GeneralSecurityException | IOException e) {
+			throw new VaultClientException("While configuring ClientRequestFactory", e);
 		}
 
 		if (hasSslConfiguration(sslConfiguration)) {

--- a/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.vault.authentication.StaticUserId;
 import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.authentication.AwsEc2AuthenticationOptions.AwsEc2AuthenticationOptionsBuilder;
 import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.SslConfiguration;
 import org.springframework.vault.support.VaultToken;
 import org.springframework.vault.support.SslConfiguration.KeyStoreConfiguration;
@@ -174,7 +175,7 @@ public class EnvironmentVaultConfiguration extends AbstractVaultConfiguration im
 			return VaultEndpoint.from(URI.create(uri));
 		}
 
-		throw new IllegalStateException("Vault URI (vault.uri) is null");
+		throw new VaultClientException("Vault URI (vault.uri) is null");
 	}
 
 	@Override
@@ -233,7 +234,7 @@ public class EnvironmentVaultConfiguration extends AbstractVaultConfiguration im
 		case KUBERNETES:
 			return kubeAuthentication();
 		default:
-			throw new IllegalStateException(String.format(
+			throw new VaultClientException(String.format(
 					"Vault authentication method %s is not supported with %s",
 					authenticationMethod, getClass().getSimpleName()));
 		}

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
@@ -146,7 +146,7 @@ public interface VaultSysOperations {
 	 *
 	 * @return the {@link Policy} or {@literal null}, if the policy was not found.
 	 * @since 2.0
-	 * @throws UnsupportedOperationException if the policy is represented as HCL.
+	 * @throws org.springframework.vault.exceptions.VaultClientException if the policy is represented as HCL.
 	 * @see <a href="https://www.vaultproject.io/api/system/policy.html">GET
 	 * /sys/policy/{name}</a>
 	 */

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysOperations.java
@@ -146,7 +146,7 @@ public interface VaultSysOperations {
 	 *
 	 * @return the {@link Policy} or {@literal null}, if the policy was not found.
 	 * @since 2.0
-	 * @throws org.springframework.vault.exceptions.VaultClientException if the policy is represented as HCL.
+	 * @throws UnsupportedOperationException if the policy is represented as HCL.
 	 * @see <a href="https://www.vaultproject.io/api/system/policy.html">GET
 	 * /sys/policy/{name}</a>
 	 */

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
@@ -230,7 +230,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 					return null;
 				}
 
-				throw new VaultHttpException(String.format("While getting policy %s", name), e, e.getStatusCode());
+				throw new VaultHttpException(String.format("While getting policy %s", name), e);
 			}
 
 			String rules = (String) response.getBody().getRequiredData().get("rules");

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
@@ -39,6 +39,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.vault.VaultException;
 import org.springframework.vault.client.VaultResponses;
+import org.springframework.vault.exceptions.VaultClientException;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.Policy;
 import org.springframework.vault.support.VaultHealth;
 import org.springframework.vault.support.VaultInitializationRequest;
@@ -228,7 +230,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 					return null;
 				}
 
-				throw e;
+				throw new VaultHttpException(String.format("While getting policy %s", name), e, e.getStatusCode());
 			}
 
 			String rules = (String) response.getBody().getRequiredData().get("rules");
@@ -241,7 +243,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 				return VaultResponses.unwrap(rules, Policy.class);
 			}
 
-			throw new UnsupportedOperationException("Cannot parse policy in HCL format");
+			throw new VaultClientException("Cannot parse policy in HCL format");
 		});
 	}
 
@@ -257,7 +259,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 			rules = OBJECT_MAPPER.writeValueAsString(policy);
 		}
 		catch (IOException e) {
-			throw new VaultException("Cannot serialize policy to JSON", e);
+			throw new VaultClientException("Cannot serialize policy to JSON", e);
 		}
 
 		vaultOperations.doWithSession(restOperations -> {

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
@@ -243,7 +243,7 @@ public class VaultSysTemplate implements VaultSysOperations {
 				return VaultResponses.unwrap(rules, Policy.class);
 			}
 
-			throw new VaultClientException("Cannot parse policy in HCL format");
+			throw new UnsupportedOperationException("Cannot parse policy in HCL format");
 		});
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
@@ -30,6 +30,7 @@ import org.springframework.util.Base64Utils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.vault.VaultException;
+import org.springframework.vault.exceptions.VaultRemoteException;
 import org.springframework.vault.support.Ciphertext;
 import org.springframework.vault.support.Hmac;
 import org.springframework.vault.support.Plaintext;
@@ -495,7 +496,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 
 				Map<String, String> data = batchData.get(i);
 				if (StringUtils.hasText(data.get("error"))) {
-					encrypted = new VaultEncryptionResult(new VaultException(
+					encrypted = new VaultEncryptionResult(new VaultRemoteException(
 							data.get("error")));
 				}
 				else {
@@ -504,7 +505,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 				}
 			}
 			else {
-				encrypted = new VaultEncryptionResult(new VaultException(
+				encrypted = new VaultEncryptionResult(new VaultRemoteException(
 						"No result for plaintext #" + i));
 			}
 
@@ -529,7 +530,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 
 				Map<String, String> data = batchData.get(i);
 				if (StringUtils.hasText(data.get("error"))) {
-					encrypted = new VaultDecryptionResult(new VaultException(
+					encrypted = new VaultDecryptionResult(new VaultRemoteException(
 							data.get("error")));
 				}
 				else {
@@ -539,7 +540,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 				}
 			}
 			else {
-				encrypted = new VaultDecryptionResult(new VaultException(
+				encrypted = new VaultDecryptionResult(new VaultRemoteException(
 						"No result for ciphertext #" + i));
 			}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
@@ -563,7 +563,7 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 			onError(requestedSecret,
 					lease,
 					new VaultHttpException(String.format("Cannot renew lease: %s",
-							VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode()));
+							VaultResponses.getError(e.getResponseBodyAsString())), e));
 		}
 		catch (RuntimeException e) {
 			onError(requestedSecret, lease, e);
@@ -633,7 +633,7 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 			onError(requestedSecret,
 					lease,
 					new VaultHttpException(String.format("Cannot revoke lease: %s",
-							VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode()));
+							VaultResponses.getError(e.getResponseBodyAsString())), e));
 		}
 		catch (RuntimeException e) {
 			onError(requestedSecret, lease, e);

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
@@ -30,8 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
-
-import lombok.extern.apachecommons.CommonsLog;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -54,8 +52,11 @@ import org.springframework.vault.core.lease.domain.RequestedSecret;
 import org.springframework.vault.core.lease.domain.RequestedSecret.Mode;
 import org.springframework.vault.core.lease.event.LeaseErrorListener;
 import org.springframework.vault.core.lease.event.LeaseListener;
+import org.springframework.vault.exceptions.VaultHttpException;
 import org.springframework.vault.support.VaultResponseSupport;
 import org.springframework.web.client.HttpStatusCodeException;
+
+import lombok.extern.apachecommons.CommonsLog;
 
 /**
  * Event-based container to request secrets from Vault and renew the associated
@@ -561,8 +562,8 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 
 			onError(requestedSecret,
 					lease,
-					new VaultException(String.format("Cannot renew lease: %s",
-							VaultResponses.getError(e.getResponseBodyAsString()))));
+					new VaultHttpException(String.format("Cannot renew lease: %s",
+							VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode()));
 		}
 		catch (RuntimeException e) {
 			onError(requestedSecret, lease, e);
@@ -631,8 +632,8 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 		catch (HttpStatusCodeException e) {
 			onError(requestedSecret,
 					lease,
-					new VaultException(String.format("Cannot revoke lease: %s",
-							VaultResponses.getError(e.getResponseBodyAsString()))));
+					new VaultHttpException(String.format("Cannot revoke lease: %s",
+							VaultResponses.getError(e.getResponseBodyAsString())), e.getStatusCode()));
 		}
 		catch (RuntimeException e) {
 			onError(requestedSecret, lease, e);

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultClientException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultClientException.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.vault.exceptions;
 
-import org.springframework.core.NestedRuntimeException;
 import org.springframework.vault.VaultException;
 
 /**
  * An exception that is Spring Vault Client specific, but not related to
- * a remote call to Vault
+ * a remote call to Vault. Common causes include message conversion failures,
+ * incorrect/impossible parameters.
  *
  * @author Michael Bell
  */

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultClientException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultClientException.java
@@ -13,26 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.vault;
+package org.springframework.vault.exceptions;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.vault.VaultException;
 
 /**
- * The Spring Vault specific {@link NestedRuntimeException} implementation.
+ * An exception that is Spring Vault Client specific, but not related to
+ * a remote call to Vault
  *
- * @author Mark Paluch
+ * @author Michael Bell
  */
 @SuppressWarnings("serial")
-public class VaultException extends NestedRuntimeException {
+public class VaultClientException extends VaultException {
 
 	/**
 	 * Create a {@code VaultException} with the specified detail message.
 	 *
 	 * @param msg the detail message.
 	 */
-	public VaultException(String msg) {
+	public VaultClientException(String msg) {
 		super(msg);
 	}
+
 
 	/**
 	 * Create a {@code VaultException} with the specified detail message and nested
@@ -41,9 +44,7 @@ public class VaultException extends NestedRuntimeException {
 	 * @param msg the detail message.
 	 * @param cause the nested exception.
 	 */
-	public VaultException(String msg, Throwable cause) {
+	public VaultClientException(String msg, Throwable cause) {
 		super(msg, cause);
 	}
-
-
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.vault;
+package org.springframework.vault.exceptions;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
 
 /**
  * The Spring Vault specific {@link NestedRuntimeException} implementation.
@@ -23,15 +25,17 @@ import org.springframework.core.NestedRuntimeException;
  * @author Mark Paluch
  */
 @SuppressWarnings("serial")
-public class VaultException extends NestedRuntimeException {
+public class VaultHttpException extends VaultRemoteException {
+	private final HttpStatus httpStatus;
 
 	/**
 	 * Create a {@code VaultException} with the specified detail message.
 	 *
 	 * @param msg the detail message.
 	 */
-	public VaultException(String msg) {
+	public VaultHttpException(String msg, HttpStatus httpStatus) {
 		super(msg);
+		this.httpStatus = httpStatus;
 	}
 
 	/**
@@ -41,9 +45,12 @@ public class VaultException extends NestedRuntimeException {
 	 * @param msg the detail message.
 	 * @param cause the nested exception.
 	 */
-	public VaultException(String msg, Throwable cause) {
+	public VaultHttpException(String msg, Throwable cause, HttpStatus httpStatus) {
 		super(msg, cause);
+		this.httpStatus = httpStatus;
 	}
 
-
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
@@ -15,14 +15,13 @@
  */
 package org.springframework.vault.exceptions;
 
-import org.springframework.core.NestedRuntimeException;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpStatusCodeException;
 
 /**
- * The Spring Vault specific {@link NestedRuntimeException} implementation.
+ * Represents an Http Call to Vault that resulted in a failure (usually non 200/204) response.
+ * Typical causes are a Vault server error, authorization/authentication failures, bad requests.
  *
- * @author Mark Paluch
+ * @author Michael Bell
  */
 @SuppressWarnings("serial")
 public class VaultHttpException extends VaultRemoteException {

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultHttpException.java
@@ -16,6 +16,8 @@
 package org.springframework.vault.exceptions;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * Represents an Http Call to Vault that resulted in a failure (usually non 200/204) response.
@@ -28,25 +30,25 @@ public class VaultHttpException extends VaultRemoteException {
 	private final HttpStatus httpStatus;
 
 	/**
-	 * Create a {@code VaultException} with the specified detail message.
-	 *
-	 * @param msg the detail message.
-	 */
-	public VaultHttpException(String msg, HttpStatus httpStatus) {
-		super(msg);
-		this.httpStatus = httpStatus;
-	}
-
-	/**
 	 * Create a {@code VaultException} with the specified detail message and nested
 	 * exception.
 	 *
 	 * @param msg the detail message.
 	 * @param cause the nested exception.
 	 */
-	public VaultHttpException(String msg, Throwable cause, HttpStatus httpStatus) {
+	public VaultHttpException(String msg, final HttpStatusCodeException cause) {
 		super(msg, cause);
-		this.httpStatus = httpStatus;
+		this.httpStatus = cause.getStatusCode();
+	}
+
+	public VaultHttpException(final String msg, final WebClientResponseException e) {
+		super(msg);
+		this.httpStatus = e.getStatusCode();
+	}
+
+	public VaultHttpException(final String msg, final HttpStatus status) {
+		super(msg);
+		this.httpStatus = status;
 	}
 
 	public HttpStatus getHttpStatus() {

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultRemoteException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultRemoteException.java
@@ -21,7 +21,9 @@ import org.springframework.vault.VaultException;
  * An exception related to a call to Vault. Normally these are related to
  * Http Codes, via the subclass  {@link VaultHttpException} implementation.
  *
- * @author Mark Paluch
+ * Other common (non Http failure) causes might be unexpected content returned from Vault.
+ *
+ * @author Michael Bell
  */
 @SuppressWarnings("serial")
 public class VaultRemoteException extends VaultException {

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultRemoteException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/VaultRemoteException.java
@@ -13,24 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.vault;
+package org.springframework.vault.exceptions;
 
-import org.springframework.core.NestedRuntimeException;
+import org.springframework.vault.VaultException;
 
 /**
- * The Spring Vault specific {@link NestedRuntimeException} implementation.
+ * An exception related to a call to Vault. Normally these are related to
+ * Http Codes, via the subclass  {@link VaultHttpException} implementation.
  *
  * @author Mark Paluch
  */
 @SuppressWarnings("serial")
-public class VaultException extends NestedRuntimeException {
+public class VaultRemoteException extends VaultException {
+
 
 	/**
 	 * Create a {@code VaultException} with the specified detail message.
 	 *
 	 * @param msg the detail message.
 	 */
-	public VaultException(String msg) {
+	public VaultRemoteException(String msg) {
 		super(msg);
 	}
 
@@ -41,7 +43,7 @@ public class VaultException extends NestedRuntimeException {
 	 * @param msg the detail message.
 	 * @param cause the nested exception.
 	 */
-	public VaultException(String msg, Throwable cause) {
+	public VaultRemoteException(String msg, Throwable cause) {
 		super(msg, cause);
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/exceptions/package-info.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/exceptions/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Spring Vault Client Exceptions. Some Exceptions still remain in other packages
+ * for compatibility purposes.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.vault.exceptions;

--- a/spring-vault-core/src/main/java/org/springframework/vault/repository/query/VaultQueryCreator.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/repository/query/VaultQueryCreator.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.data.repository.query.parser.Part.IgnoreCaseType;
 import org.springframework.data.repository.query.parser.Part.Type;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.repository.mapping.VaultPersistentEntity;
 import org.springframework.vault.repository.mapping.VaultPersistentProperty;
 
@@ -162,7 +163,7 @@ public class VaultQueryCreator extends
 			return new Criteria<>(accessor.nextString(parameters),
 					(value, it) -> !it.equals(value));
 		default:
-			throw new IllegalArgumentException("Unsupported keyword!");
+			throw new VaultClientException("Unsupported keyword!");
 		}
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/AbstractResult.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/AbstractResult.java
@@ -85,8 +85,8 @@ public abstract class AbstractResult<V> {
 		if (isSuccessful()) {
 			return get0();
 		}
-
-		throw new VaultException(exception.getMessage());
+		// Mark: This seemed wrong, and lost information
+		throw exception;
 	}
 
 	/**

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/Certificate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/Certificate.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.util.Assert;
 import org.springframework.vault.VaultException;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Value object representing a certificate consisting of the certificate and the issuer
@@ -106,7 +107,7 @@ public class Certificate {
 			return KeystoreUtil.getCertificate(bytes);
 		}
 		catch (IOException | CertificateException e) {
-			throw new VaultException("Cannot create Certificate from certificate", e);
+			throw new VaultClientException("Cannot create Certificate from certificate", e);
 		}
 	}
 
@@ -123,7 +124,7 @@ public class Certificate {
 			return KeystoreUtil.getCertificate(bytes);
 		}
 		catch (IOException | CertificateException e) {
-			throw new VaultException(
+			throw new VaultClientException(
 					"Cannot create Certificate from issuing CA certificate", e);
 		}
 	}
@@ -141,7 +142,7 @@ public class Certificate {
 					getX509IssuerCertificate());
 		}
 		catch (GeneralSecurityException | IOException e) {
-			throw new VaultException("Cannot create KeyStore", e);
+			throw new VaultClientException("Cannot create KeyStore", e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.util.Assert;
 import org.springframework.vault.VaultException;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Value object representing a certificate bundle consisting of a private key, the
@@ -93,7 +94,7 @@ public class CertificateBundle extends Certificate {
 			return KeystoreUtil.getRSAKeySpec(bytes);
 		}
 		catch (IOException e) {
-			throw new VaultException("Cannot create KeySpec from private key", e);
+			throw new VaultClientException("Cannot create KeySpec from private key", e);
 		}
 	}
 
@@ -114,7 +115,7 @@ public class CertificateBundle extends Certificate {
 					getX509Certificate(), getX509IssuerCertificate());
 		}
 		catch (GeneralSecurityException | IOException e) {
-			throw new VaultException("Cannot create KeyStore", e);
+			throw new VaultClientException("Cannot create KeyStore", e);
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/KeystoreUtil.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/KeystoreUtil.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.vault.exceptions.VaultClientException;
+
 /**
  * Keystore utility to create a {@link KeyStore} containing a {@link CertificateBundle}
  * with the certificate chain and its private key.
@@ -169,7 +171,7 @@ class KeystoreUtil {
 
 		Asn1Object sequence = parser.read();
 		if (sequence.getType() != DerParser.SEQUENCE) {
-			throw new IllegalStateException("Invalid DER: not a sequence");
+			throw new VaultClientException("Invalid DER: not a sequence");
 		}
 
 		// Parse inside the sequence
@@ -272,7 +274,7 @@ class KeystoreUtil {
 			int tag = in.read();
 
 			if (tag == -1) {
-				throw new IllegalStateException(
+				throw new VaultClientException(
 						"Invalid DER: stream too short, missing tag");
 			}
 
@@ -281,7 +283,7 @@ class KeystoreUtil {
 			byte[] value = new byte[length];
 			int n = in.read(value);
 			if (n < length) {
-				throw new IllegalStateException(
+				throw new VaultClientException(
 						"Invalid DER: stream too short, missing value");
 			}
 
@@ -308,7 +310,7 @@ class KeystoreUtil {
 
 			int i = in.read();
 			if (i == -1) {
-				throw new IllegalStateException("Invalid DER: length missing");
+				throw new VaultClientException("Invalid DER: length missing");
 			}
 
 			// A single byte short length
@@ -320,14 +322,14 @@ class KeystoreUtil {
 
 			// We can't handle length longer than 4 bytes
 			if (i >= 0xFF || num > 4) {
-				throw new IllegalStateException("Invalid DER: length field too big (" + i
+				throw new VaultClientException("Invalid DER: length field too big (" + i
 						+ ")");
 			}
 
 			byte[] bytes = new byte[num];
 			int n = in.read(bytes);
 			if (n < num) {
-				throw new IllegalStateException("Invalid DER: length too short");
+				throw new VaultClientException("Invalid DER: length too short");
 			}
 
 			return new BigInteger(1, bytes).intValue();
@@ -401,7 +403,7 @@ class KeystoreUtil {
 		DerParser getParser() throws IOException {
 
 			if (!isConstructed()) {
-				throw new IllegalStateException(
+				throw new VaultClientException(
 						"Invalid DER: can't parse primitive entity");
 			}
 
@@ -416,7 +418,7 @@ class KeystoreUtil {
 		BigInteger getInteger() {
 
 			if (type != DerParser.INTEGER) {
-				throw new IllegalStateException("Invalid DER: object is not integer");
+				throw new VaultClientException("Invalid DER: object is not integer");
 			}
 
 			return new BigInteger(value);

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/Policy.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/Policy.java
@@ -51,6 +51,7 @@ import lombok.EqualsAndHashCode;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.Policy.PolicyDeserializer;
 import org.springframework.vault.support.Policy.PolicySerializer;
 
@@ -373,7 +374,7 @@ public class Policy {
 							Capability capability = BuiltinCapabilities.find(value);
 
 							if (capability == null) {
-								throw new IllegalArgumentException("Cannot resolve "
+								throw new VaultClientException("Cannot resolve "
 										+ value + " to a capability");
 							}
 							return capability;
@@ -741,7 +742,7 @@ public class Policy {
 					return Duration.ofHours(Long.parseLong(matcher.group(1)));
 				}
 
-				throw new IllegalArgumentException("Unsupported duration value: " + value);
+				throw new VaultClientException("Unsupported duration value: " + value);
 			}
 		}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/SslConfiguration.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/SslConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * SSL configuration.
@@ -455,7 +456,7 @@ public class SslConfiguration {
 
 		@Override
 		public InputStream getInputStream() throws IOException {
-			throw new UnsupportedOperationException("Empty resource");
+			throw new VaultClientException("Empty resource");
 		}
 	}
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultResponseSupport.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultResponseSupport.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.lang.Nullable;
+import org.springframework.vault.exceptions.VaultClientException;
 
 /**
  * Value object to bind generic Vault HTTP API responses.
@@ -81,7 +82,7 @@ public class VaultResponseSupport<T> {
 			return auth;
 		}
 
-		throw new IllegalStateException("Auth field is empty");
+		throw new VaultClientException("Auth field is empty");
 	}
 
 	/**
@@ -109,7 +110,7 @@ public class VaultResponseSupport<T> {
 			return data;
 		}
 
-		throw new IllegalStateException("Data field is empty");
+		throw new VaultClientException("Data field is empty");
 	}
 
 	/**

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateIntegrationTests.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.Policy;
 import org.springframework.vault.support.VaultMount;
 import org.springframework.vault.support.VaultUnsealStatus;
@@ -164,7 +163,7 @@ public class VaultSysTemplateIntegrationTests extends IntegrationTestSupport {
 		assertThat(root).isNull();
 	}
 
-	@Test(expected = VaultClientException.class)
+	@Test(expected = UnsupportedOperationException.class)
 	public void shouldReadDefaultPolicy() {
 
 		assumeTrue(vaultVersion.isGreaterThanOrEqualTo(Version.parse("0.6.1")));

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateIntegrationTests.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.Policy;
 import org.springframework.vault.support.VaultMount;
 import org.springframework.vault.support.VaultUnsealStatus;
@@ -163,7 +164,7 @@ public class VaultSysTemplateIntegrationTests extends IntegrationTestSupport {
 		assertThat(root).isNull();
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test(expected = VaultClientException.class)
 	public void shouldReadDefaultPolicy() {
 
 		assumeTrue(vaultVersion.isGreaterThanOrEqualTo(Version.parse("0.6.1")));

--- a/spring-vault-core/src/test/java/org/springframework/vault/util/Settings.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/util/Settings.java
@@ -18,6 +18,7 @@ package org.springframework.vault.util;
 import java.io.File;
 
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.vault.exceptions.VaultClientException;
 import org.springframework.vault.support.SslConfiguration;
 import org.springframework.vault.support.VaultToken;
 
@@ -69,7 +70,7 @@ public class Settings {
 			searchLevel = searchLevel.getParentFile();
 		}
 
-		throw new IllegalStateException(String.format(
+		throw new VaultClientException(String.format(
 				"Cannot find work directory in %s or any parent directories",
 				directory.getAbsoluteFile()));
 	}


### PR DESCRIPTION
1. Virtually all exceptions (with a few exceptions, please review) were remapped to this hierarchy

VaultException (mostly serves as a root, few instantiated)
-- VaultClientException - where the state or a mapping error says "Hey this isn't Vault per se, but a bad state"
-- VaultRemoteException - mostly a container class but represents fatal results from a call to Vault
----- VaultHttpExceptions - Most Vault calls map here.

2. I agree a cleaner mapper is wise. Right now things are a mess! I agree with your concept, but felt it belonged in another PR. One of the issues is some things have an exception mapper (VaultResponses), others don't.

3. I couldn't run most tests, because apparently they require a local workdir and Vault -please clarify how I can run this. As an aside, while I don't have it working perfectly - testContainers.org is a lovely way to run integration tests with a dockerized Vault.