### PR TITLE
Possible implementation of SessionManagerListener

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManager.java
@@ -19,8 +19,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.swing.text.html.Option;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerSupport.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerSupport.java
@@ -178,6 +178,22 @@ public abstract class LifecycleAwareSessionManagerSupport {
 		return loginToken.getLeaseDuration().compareTo(validTtlThreshold) <= 0;
 	}
 
+	protected void failedToRenew() {
+		try {
+			listener.onSessionRenewalFailure();
+		} catch (RuntimeException e) {
+			logger.error("Error in listener", e);
+		}
+	}
+
+	protected void successfullyRenewed() {
+		try {
+			listener.onSessionRenewalSuccess();
+		} catch (RuntimeException e) {
+			logger.error("Error in listener", e);
+		}
+	}
+
 	/**
 	 * This one-shot trigger creates only one execution time to trigger an execution only
 	 * once.

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerSupport.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LifecycleAwareSessionManagerSupport.java
@@ -20,16 +20,16 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
 import org.springframework.util.Assert;
 import org.springframework.vault.support.VaultToken;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * Support class to build Lifecycle-aware Session Manager implementations, defining common
@@ -50,6 +50,8 @@ public abstract class LifecycleAwareSessionManagerSupport {
 
 	private static final RefreshTrigger DEFAULT_TRIGGER = new FixedTimeoutRefreshTrigger(
 			REFRESH_PERIOD_BEFORE_EXPIRY, TimeUnit.SECONDS);
+
+	protected final SessionManagerListener listener;
 
 	/**
 	 * Logger available to subclasses.
@@ -94,12 +96,28 @@ public abstract class LifecycleAwareSessionManagerSupport {
 	 */
 	public LifecycleAwareSessionManagerSupport(TaskScheduler taskScheduler,
 			RefreshTrigger refreshTrigger) {
+		this(taskScheduler, refreshTrigger, new LoggingSessionListener());
+	}
+
+	/**
+	 * Create a {@link LifecycleAwareSessionManager} given {@link TaskScheduler},
+	 * {@link RefreshTrigger}, {@link SessionManagerListener}
+	 *
+	 * @param taskScheduler must not be {@literal null}.
+	 * @param refreshTrigger must not be {@literal null}.
+	 * @param sessionManagerListener must not be {@literal null}.
+	 */
+	public LifecycleAwareSessionManagerSupport(TaskScheduler taskScheduler,
+											   RefreshTrigger refreshTrigger,
+											   SessionManagerListener sessionManagerListener) {
 
 		Assert.notNull(taskScheduler, "TaskScheduler must not be null");
 		Assert.notNull(refreshTrigger, "RefreshTrigger must not be null");
+		Assert.notNull(sessionManagerListener, "SessionManagerListener must not be null");
 
 		this.taskScheduler = taskScheduler;
 		this.refreshTrigger = refreshTrigger;
+		this.listener = sessionManagerListener;
 	}
 
 	/**

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
@@ -1,27 +1,19 @@
 package org.springframework.vault.authentication;
 
-import java.util.Optional;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.vault.support.VaultToken;
 
 public class LoggingSessionListener implements SessionManagerListener {
     protected final Log logger = LogFactory.getLog(getClass());
 
-    @Override
-    public Optional<VaultToken> onSessionRenewalNeeded() {
-        logger.info("Renewing token");
-        return Optional.empty();
-    }
 
     @Override
-    public void onSessionRenewalSuccess(final VaultToken newToken) {
+    public void onSessionRenewalSuccess(final SessionManager sessionManager) {
         logger.debug("Successfully renewed token!");
     }
 
     @Override
-    public void onSessionRenewalFailure() {
+    public void onSessionRenewalFailure(SessionManager sessionManager) {
         logger.debug("Failed to successfully remove token!");
     }
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
@@ -1,0 +1,27 @@
+package org.springframework.vault.authentication;
+
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.vault.support.VaultToken;
+
+public class LoggingSessionListener implements SessionManagerListener {
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    @Override
+    public Optional<VaultToken> onSessionRenewalNeeded() {
+        logger.info("Renewing token");
+        return Optional.empty();
+    }
+
+    @Override
+    public void onSessionRenewalSuccess(final VaultToken newToken) {
+        logger.debug("Successfully renewed token!");
+    }
+
+    @Override
+    public void onSessionRenewalFailure(final VaultToken oldToken) {
+        logger.debug("Failed to successfully remove token!");
+    }
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
@@ -21,7 +21,7 @@ public class LoggingSessionListener implements SessionManagerListener {
     }
 
     @Override
-    public void onSessionRenewalFailure(final VaultToken oldToken) {
+    public void onSessionRenewalFailure() {
         logger.debug("Failed to successfully remove token!");
     }
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/LoggingSessionListener.java
@@ -8,12 +8,12 @@ public class LoggingSessionListener implements SessionManagerListener {
 
 
     @Override
-    public void onSessionRenewalSuccess(final SessionManager sessionManager) {
+    public void onSessionRenewalSuccess() {
         logger.debug("Successfully renewed token!");
     }
 
     @Override
-    public void onSessionRenewalFailure(SessionManager sessionManager) {
+    public void onSessionRenewalFailure() {
         logger.debug("Failed to successfully remove token!");
     }
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/SessionManagerListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/SessionManagerListener.java
@@ -1,25 +1,14 @@
 package org.springframework.vault.authentication;
 
-import java.util.Optional;
-
-import org.springframework.vault.support.VaultToken;
-
 /**
  * Optional listeners, to get events from LifeCycleAwareSessionManager
  */
 public interface SessionManagerListener {
 
     /**
-     * SessionManager has detected a Token needs to be renewed.
-     * @return Optional.empty() if not performing the renewal for the SessionManager, otherwise return a valid Optional<VaultToken>
-     */
-    Optional<VaultToken> onSessionRenewalNeeded();
-
-    /**
      * Called when SessionManager has succeeded in renewing the Token.
-     * @param newToken The new Token obtained
      */
-    void onSessionRenewalSuccess(VaultToken newToken);
+    void onSessionRenewalSuccess();
 
     /**
      * Called when SessionManager has failed to renew the token

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/SessionManagerListener.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/SessionManagerListener.java
@@ -1,0 +1,28 @@
+package org.springframework.vault.authentication;
+
+import java.util.Optional;
+
+import org.springframework.vault.support.VaultToken;
+
+/**
+ * Optional listeners, to get events from LifeCycleAwareSessionManager
+ */
+public interface SessionManagerListener {
+
+    /**
+     * SessionManager has detected a Token needs to be renewed.
+     * @return Optional.empty() if not performing the renewal for the SessionManager, otherwise return a valid Optional<VaultToken>
+     */
+    Optional<VaultToken> onSessionRenewalNeeded();
+
+    /**
+     * Called when SessionManager has succeeded in renewing the Token.
+     * @param newToken The new Token obtained
+     */
+    void onSessionRenewalSuccess(VaultToken newToken);
+
+    /**
+     * Called when SessionManager has failed to renew the token
+     */
+    void onSessionRenewalFailure();
+}


### PR DESCRIPTION
1. Right now I allow for renewal in the event. This allows for moving all of the code into there for renewal for the two LifecycleSessionManager, but is currently dubious logic.
2. My reactive fu is weak - so the Reactive part needs scrutiny.

Arguably instead of hitting the subclass we need separate implementations of listener in the two Lifecycle concrete classes to preserve reactive semantics. Then the renewal needed would return some form of TokenWrapper directly.