### PR TITLE
GitHub/issue 215/rotating credentials have lease

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
@@ -300,12 +300,11 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 
 			Lease lease;
 
-			if (StringUtils.hasText(secrets.getLeaseId())) {
+			if (isRotatingGenericSecret(requestedSecret, secrets)) {
+				lease = Lease.fromTimeToLive(secrets.getLeaseDuration());
+			} else if (StringUtils.hasText(secrets.getLeaseId())) {
 				lease = Lease.of(secrets.getLeaseId(), secrets.getLeaseDuration(),
 						secrets.isRenewable());
-			}
-			else if (isRotatingGenericSecret(requestedSecret, secrets)) {
-				lease = Lease.fromTimeToLive(secrets.getLeaseDuration());
 			}
 			else {
 				lease = Lease.none();
@@ -737,7 +736,7 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 				return true;
 			}
 
-			if (!lease.hasLeaseId() && requestedSecret.getMode() == Mode.ROTATE) {
+			if (requestedSecret.getMode() == Mode.ROTATE) {
 				return true;
 			}
 

--- a/src/test/bash/create_certificates.sh
+++ b/src/test/bash/create_certificates.sh
@@ -24,11 +24,11 @@ fi
 
 KEYTOOL=keytool
 
-if [  ! -x "${KEYTOOL}" ] ; then
+if [  ! -x "$(which keytool)" ] ; then
    KEYTOOL=${JAVA_HOME}/bin/keytool
 fi
 
-if [  ! -x "${KEYTOOL}" ] ; then
+if [  ! -x "$(which ${KEYTOOL})" ] ; then
    echo "[ERROR] No keytool in PATH/JAVA_HOME"
    exit 1
 fi


### PR DESCRIPTION
For issue #215 , expect rotating credentials to have a leaseId.  Also includes a fix for test bash script where keytool was already in path