### PR TITLE
Moving lease data into object in lease PUT

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/SecretLeaseContainer.java
@@ -35,6 +35,7 @@ import lombok.extern.apachecommons.CommonsLog;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -592,11 +593,16 @@ public class SecretLeaseContainer extends SecretLeaseEventPublisher implements
 
 	@SuppressWarnings("unchecked")
 	private Lease renew(Lease lease) {
+		final Map<String, String> leaseRenewalData = new HashMap<>();
+		leaseRenewalData.put("lease_id", lease.getLeaseId());
+		leaseRenewalData.put("increment", Long.toString(lease.getLeaseDuration().getSeconds()));
+
+		HttpEntity<Object> leaseRenewalEntity = new HttpEntity<>(leaseRenewalData);
+
 
 		ResponseEntity<Map<String, Object>> entity = operations
 				.doWithSession(restOperations -> (ResponseEntity) restOperations
-						.exchange("sys/renew/{leaseId}", HttpMethod.PUT, null, Map.class,
-								lease.getLeaseId()));
+						.exchange("sys/renew", HttpMethod.PUT, leaseRenewalEntity, Map.class));
 
 		Assert.state(entity != null && entity.getBody() != null,
 				"Renew response must not be null");


### PR DESCRIPTION
It appears that maybe this URL just needs to be passed an object instead of having the `lease_id` embedded in the URL and that solves most of the problems I have.

The URL is still deprecated, but this solves the immediate problem that the URL with the embedded lease_id no longer has default permissions.

This will fix Issue #262.