### PR TITLE
Configure service account id and project id explicitly

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/DefaultGcpProjectIdProvider.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/DefaultGcpProjectIdProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.authentication;
+
+import org.springframework.util.StringUtils;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+
+/**
+ * Default implementation to obtain a GCP project id for GCP IAM authentication.
+ * Used by {@link GcpIamAuthentication}.
+ *
+ * @author Magnus Jungsbluth
+ * @since 2.1
+ * @see GcpIamAuthentication
+ */
+public class DefaultGcpProjectIdProvider implements GcpProjectIdProvider {
+
+    @Override
+    public String getProjectId(GoogleCredential credential) {
+        if (StringUtils.isEmpty(credential.getServiceAccountProjectId())) {
+            return "-";
+        } else {
+            return credential.getServiceAccountProjectId();
+        }
+    }
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/DefaultGcpServiceAccountIdProvider.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/DefaultGcpServiceAccountIdProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.authentication;
+
+import org.springframework.util.Assert;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+
+/**
+ * Default implementation to obtain a service account id for GCP IAM authentication.
+ * Used by {@link GcpIamAuthentication}.
+ *
+ * @author Magnus Jungsbluth
+ * @since 2.1
+ * @see GcpIamAuthentication
+ */
+public class DefaultGcpServiceAccountIdProvider implements GcpServiceAccountIdProvider {
+
+    @Override
+    public String getServiceAccountId(GoogleCredential credential) {
+        Assert.notNull(credential.getServiceAccountId(), "The configured GoogleCredential does not represent a service account. Configure the service account id manually");
+
+        return credential.getServiceAccountId();
+    }
+
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthentication.java
@@ -125,8 +125,8 @@ public class GcpIamAuthentication extends GcpJwtAuthenticationSupport implements
 
 	protected String signJwt() {
 
-		String projectId = credential.getServiceAccountProjectId();
-		String serviceAccount = credential.getServiceAccountId();
+		String projectId = options.getProjectIdProvider().getProjectId(credential);
+		String serviceAccount = options.getServiceAccountIdProvider().getServiceAccountId(credential);
 		Map<String, Object> jwtPayload = getJwtPayload(options, serviceAccount);
 
 		Iam iam = new Builder(httpTransport, JSON_FACTORY, credential)

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpProjectIdProvider.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpProjectIdProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.authentication;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+
+/**
+ * Interface to obtain a GCP project id for GCP IAM authentication.
+ * Implementations are used by {@link GcpIamAuthentication}.
+ *
+ * @author Magnus Jungsbluth
+ * @since 2.1
+ * @see GcpIamAuthentication
+ */
+@FunctionalInterface
+public interface GcpProjectIdProvider {
+
+	/**
+	 * Get a the GCP project id to used in Google Cloud IAM API calls.
+	 *
+	 * @return the service account id to use.
+	 */
+	String getProjectId(GoogleCredential credential);
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpServiceAccountIdProvider.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpServiceAccountIdProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.authentication;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+
+/**
+ * Interface to obtain a service account id for GCP IAM authentication.
+ * Implementations are used by {@link GcpIamAuthentication}.
+ *
+ * @author Magnus Jungsbluth
+ * @since 2.1
+ * @see GcpIamAuthentication
+ */
+@FunctionalInterface
+public interface GcpServiceAccountIdProvider {
+
+	/**
+	 * Get a the service account id (email) to be placed in the signed JWT.
+	 *
+	 * @return the service account id to use.
+	 */
+	String getServiceAccountId(GoogleCredential credential);
+}

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/GcpIamAuthenticationOptionsBuilderUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/GcpIamAuthenticationOptionsBuilderUnitTests.java
@@ -1,0 +1,96 @@
+package org.springframework.vault.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.security.PrivateKey;
+
+import org.junit.Test;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+
+/**
+ * Unit tests for {@link GcpIamAuthenticationOptions.GcpIamAuthenticationOptionsBuilder}
+ */
+public class GcpIamAuthenticationOptionsBuilderUnitTests {
+
+	private GoogleCredential createGoogleCredential() {
+		GoogleCredential credential = new GoogleCredential.Builder().setServiceAccountId("hello@world")
+				.setServiceAccountProjectId("foobar")
+				.setServiceAccountPrivateKey(mock(PrivateKey.class))
+				.setServiceAccountPrivateKeyId("key-id").build();
+		credential.setAccessToken("foobar");
+		return credential;
+	}
+
+	@Test
+	public void shouldDefaultToCredentialServiceAccountId() {
+		GoogleCredential credential = createGoogleCredential();
+		GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .role("foo")
+                .build();
+
+		assertThat(options.getServiceAccountIdProvider().getServiceAccountId(credential)).isEqualTo("hello@world");
+	}
+
+	@Test
+	public void shouldAllowServiceAccountIdOverride() {
+        GoogleCredential credential = createGoogleCredential();
+		GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .serviceAccountId("override@foo.com")
+                .role("foo")
+				.build();
+
+		assertThat(options.getServiceAccountIdProvider().getServiceAccountId(credential)).isEqualTo("override@foo.com");
+	}
+
+    @Test
+    public void shouldAllowServiceAccountIdProviderOverride() {
+        GoogleCredential credential = createGoogleCredential();
+        GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .serviceAccountIdProvider((GoogleCredential googleCredential) -> "override@foo.com")
+                .role("foo")
+                .build();
+
+        assertThat(options.getServiceAccountIdProvider().getServiceAccountId(credential)).isEqualTo("override@foo.com");
+    }
+
+    @Test
+    public void shouldDefaultToCredentialProjectId() {
+        GoogleCredential credential = createGoogleCredential();
+        GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .role("foo")
+                .build();
+
+        assertThat(options.getProjectIdProvider().getProjectId(credential)).isEqualTo("foobar");
+    }
+
+    @Test
+    public void shouldAllowProjectIdOverride() {
+        GoogleCredential credential = createGoogleCredential();
+        GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .projectId("my-project")
+                .role("foo")
+                .build();
+
+        assertThat(options.getProjectIdProvider().getProjectId(credential)).isEqualTo("my-project");
+    }
+
+    @Test
+    public void shouldAllowProjectIdProviderOverride() {
+        GoogleCredential credential = createGoogleCredential();
+        GcpIamAuthenticationOptions options = GcpIamAuthenticationOptions.builder()
+                .credential(credential)
+                .projectIdProvider((GoogleCredential googleCredential) -> "my-project")
+                .role("foo")
+                .build();
+
+        assertThat(options.getProjectIdProvider().getProjectId(credential)).isEqualTo("my-project");
+    }
+
+}


### PR DESCRIPTION
Configure service account id and GCP project id explicitly for running without local service account credentials. Fixes #261 