### PR TITLE
URL Cleanup

### DIFF
--- a/docs/font-awesome/font/fontawesome-webfont.svg
+++ b/docs/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2AuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2AuthenticationOptions.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
 public class AwsEc2AuthenticationOptions {
 
 	public static final URI DEFAULT_PKCS7_IDENTITY_DOCUMENT_URI = URI
-			.create("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7");
+			.create("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7");
 
 	public static final String DEFAULT_AWS_AUTHENTICATION_PATH = "aws-ec2";
 

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
@@ -63,7 +63,7 @@ public class AwsEc2AuthenticationUnitTests {
 	public void shouldObtainIdentityDocument() {
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("Hello, world"));
 
@@ -80,7 +80,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.role("ami").build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("Hello, world"));
 
@@ -102,7 +102,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.builder().nonce(nonce).build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("value"));
 
@@ -138,7 +138,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.nonce(nonce).build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("value"));
 
@@ -168,7 +168,7 @@ public class AwsEc2AuthenticationUnitTests {
 	public void loginShouldFailWhileObtainingIdentityDocument() {
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andRespond(withServerError());
 
 		new AwsEc2Authentication(restTemplate).login();

--- a/spring-vault-distribution/src/assembly/docs.xml
+++ b/spring-vault-distribution/src/assembly/docs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
 	<id>docs</id>
 	<formats>
 		<format>dir</format>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://blindsignals.com (200) with 1 occurrences could not be migrated:  
   ([https](https://blindsignals.com) result SSLHandshakeException).
* [ ] http://erik.eae.net/archives/2007/07/27/18.54.15/ (200) with 1 occurrences could not be migrated:  
   ([https](https://erik.eae.net/archives/2007/07/27/18.54.15/) result SSLHandshakeException).
* [ ] http://javascript.nwbox.com/IEContentLoaded/ (200) with 1 occurrences could not be migrated:  
   ([https](https://javascript.nwbox.com/IEContentLoaded/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 (AnnotatedConnectException) with 6 occurrences migrated to:  
  https://169.254.169.254/latest/dynamic/instance-identity/pkcs7 ([https](https://169.254.169.254/latest/dynamic/instance-identity/pkcs7) result ConnectTimeoutException).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:443 with 1 occurrences