### PR TITLE
URL Cleanup

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2AuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AwsEc2AuthenticationOptions.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
 public class AwsEc2AuthenticationOptions {
 
 	public static final URI DEFAULT_PKCS7_IDENTITY_DOCUMENT_URI = URI
-			.create("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7");
+			.create("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7");
 
 	public static final String DEFAULT_AWS_AUTHENTICATION_PATH = "aws-ec2";
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AzureMsiAuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AzureMsiAuthenticationOptions.java
@@ -38,10 +38,10 @@ public class AzureMsiAuthenticationOptions {
 	public static final String DEFAULT_AZURE_AUTHENTICATION_PATH = "azure";
 
 	public static final URI DEFAULT_INSTANCE_METADATA_SERVICE_URI = URI
-			.create("http://169.254.169.254/metadata/instance?api-version=2017-08-01");
+			.create("https://169.254.169.254/metadata/instance?api-version=2017-08-01");
 
 	public static final URI DEFAULT_IDENTITY_TOKEN_SERVICE_URI = URI
-			.create("http://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01");
+			.create("https://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01");
 
 	/**
 	 * Path of the azure authentication backend mount.

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AwsEc2AuthenticationUnitTests.java
@@ -63,7 +63,7 @@ public class AwsEc2AuthenticationUnitTests {
 	public void shouldObtainIdentityDocument() {
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("Hello, world"));
 
@@ -80,7 +80,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.role("ami").build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("Hello, world"));
 
@@ -102,7 +102,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.builder().nonce(nonce).build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("value"));
 
@@ -138,7 +138,7 @@ public class AwsEc2AuthenticationUnitTests {
 				.nonce(nonce).build();
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andExpect(method(HttpMethod.GET)) //
 				.andRespond(withSuccess().body("value"));
 
@@ -168,7 +168,7 @@ public class AwsEc2AuthenticationUnitTests {
 	public void loginShouldFailWhileObtainingIdentityDocument() {
 
 		mockRest.expect(
-				requestTo("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
+				requestTo("https://169.254.169.254/latest/dynamic/instance-identity/pkcs7")) //
 				.andRespond(withServerError());
 
 		new AwsEc2Authentication(restTemplate).login();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://blindsignals.com (200) with 1 occurrences could not be migrated:  
   ([https](https://blindsignals.com) result SSLHandshakeException).
* [ ] http://erik.eae.net/archives/2007/07/27/18.54.15/ (200) with 1 occurrences could not be migrated:  
   ([https](https://erik.eae.net/archives/2007/07/27/18.54.15/) result SSLHandshakeException).
* [ ] http://javascript.nwbox.com/IEContentLoaded/ (200) with 1 occurrences could not be migrated:  
   ([https](https://javascript.nwbox.com/IEContentLoaded/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 (AnnotatedConnectException) with 6 occurrences migrated to:  
  https://169.254.169.254/latest/dynamic/instance-identity/pkcs7 ([https](https://169.254.169.254/latest/dynamic/instance-identity/pkcs7) result ConnectTimeoutException).
* [ ] http://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01 (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01 ([https](https://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01) result ConnectTimeoutException).
* [ ] http://169.254.169.254/metadata/instance?api-version=2017-08-01 (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://169.254.169.254/metadata/instance?api-version=2017-08-01 ([https](https://169.254.169.254/metadata/instance?api-version=2017-08-01) result ConnectTimeoutException).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1/context with 1 occurrences
* http://127.0.0.1:443/ with 1 occurrences
* http://127.0.0.1:80/context/foo with 1 occurrences
* http://metadata/computeMetadata/v1/instance/service-accounts/ with 1 occurrences
* http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://localhost:8200/vault/dev-role&format=full with 1 occurrences