### PR TITLE
Add path to URL

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/client/VaultClients.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/VaultClients.java
@@ -236,7 +236,7 @@ public class VaultClients {
 
 	private static String toBaseUri(VaultEndpoint endpoint) {
 		return endpoint.getScheme() + "://" + endpoint.getHost() + ":"
-				+ endpoint.getPort() + "/v1";
+				+ endpoint.getPort() + "/" + endpoint.getPath() + "/v1";
 	}
 
 	/**


### PR DESCRIPTION
Add VaultEndpoint.path in creation of final URI in
VaultClients.toBaseUri method.

Fixes gh-413