### PR TITLE
Add constructor to VaultTemplate that takes a VaultEndpoint, a ClientAuthentication and RestTemplate

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTemplate.java
@@ -97,6 +97,23 @@ public class VaultTemplate implements InitializingBean, VaultOperations, Disposa
 		this.sessionTemplate = doCreateSessionTemplate(endpointProvider, requestFactory);
 	}
 
+    public VaultTemplate(VaultEndpoint vaultEndpoint, ClientAuthentication clientAuthentication, RestTemplate restTemplate) {
+
+        Assert.notNull(vaultEndpoint, "VaultEndpoint must not be null");
+        Assert.notNull(clientAuthentication, "ClientAuthentication must not be null");
+        Assert.notNull(restTemplate, "RestTemplate must not be null");
+
+        this.sessionManager = new SimpleSessionManager(clientAuthentication);
+        this.dedicatedSessionManager = true;
+
+        ClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+
+        VaultEndpointProvider endpointProvider = SimpleVaultEndpointProvider.of(vaultEndpoint);
+
+        this.statelessTemplate = restTemplate;
+        this.sessionTemplate = doCreateSessionTemplate(endpointProvider, requestFactory);
+    }
+
 	/**
 	 * Create a new {@link VaultTemplate} with a {@link VaultEndpoint}, and
 	 * {@link ClientHttpRequestFactory}. This constructor does not use a


### PR DESCRIPTION
This refers to #572. This is far from being finished (testing, documentation etc), also I'm not sure if it is a good idea at all to add this constructor. I thought it would be helpful to have some code to talk about