### PR TITLE
Adding support of KV Patch operation

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/SecretNotFoundException.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/SecretNotFoundException.java
@@ -1,0 +1,29 @@
+package org.springframework.vault.core;
+
+import org.springframework.vault.VaultException;
+
+/**
+ * An exception which is used in case that no secret is found from Vault server.
+ *
+ * @author Younghwan Jang
+ * @since 2.3
+ */
+public class SecretNotFoundException extends VaultException {
+    /**
+     * Create a {@code SecretNotFoundException} with the specified detail message.
+     * @param msg the detail message.
+     */
+    public SecretNotFoundException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a {@code SecretNotFoundException} with the specified detail message and nested
+     * exception.
+     * @param msg the detail message.
+     * @param cause the nested exception.
+     */
+    public SecretNotFoundException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValue1Template.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValue1Template.java
@@ -24,6 +24,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultResponseSupport;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * Default implementation of {@link VaultKeyValueOperations} for the Key/Value backend
@@ -104,6 +105,11 @@ class VaultKeyValue1Template extends VaultKeyValueAccessor implements VaultKeyVa
 		Assert.hasText(path, "Path must not be empty");
 
 		doWrite(createDataPath(path), body);
+	}
+
+	@Override
+	public boolean patch(String path, Map<String, ?> kv) {
+		throw new IllegalStateException("Patch operation is available only in KV secret engine V2");
 	}
 
 	@Override

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValueAccessor.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValueAccessor.java
@@ -16,10 +16,12 @@
 package org.springframework.vault.core;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -107,6 +109,8 @@ abstract class VaultKeyValueAccessor implements VaultKeyValueOperationsSupport {
 		if (response != null) {
 
 			JsonNode jsonNode = getJsonNode(response);
+			JsonNode jsonMeta = response.getRequiredData().at("/metadata");
+			response.setMetadata(mapper.convertValue(jsonMeta, new TypeReference<Map<String, Object>>() {}));
 
 			return mappingFunction.apply(response, deserialize(jsonNode, deserializeAs));
 		}

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValueOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultKeyValueOperations.java
@@ -19,6 +19,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.vault.support.VaultResponse;
 import org.springframework.vault.support.VaultResponseSupport;
 
+import java.util.Map;
+
 /**
  * Interface that specifies a basic set of Vault operations using Vault's Key/Value secret
  * backend. Paths used in this operations interface are relative and outgoing requests
@@ -58,5 +60,13 @@ public interface VaultKeyValueOperations extends VaultKeyValueOperationsSupport 
 	 * @param body must not be {@literal null}.
 	 */
 	void put(String path, Object body);
+
+	/**
+	 * Updates the secret at {@code path} without removing the existing secrets.
+	 * @param path must not be {@literal null}.
+	 * @param kv must not be {@literal null}.
+	 * @return true if the patch operation is successful, false otherwise.
+	 */
+	boolean patch(String path, Map<String, ?> kv);
 
 }

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultKeyValueTemplateVersionedIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultKeyValueTemplateVersionedIntegrationTests.java
@@ -15,11 +15,22 @@
  */
 package org.springframework.vault.core;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.vault.core.VaultKeyValueOperationsSupport.KeyValueBackend;
+import org.springframework.vault.support.VaultResponse;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for {@link VaultKeyValue2Template} using the versioned Key/Value (k/v
@@ -33,6 +44,29 @@ class VaultKeyValueTemplateVersionedIntegrationTests extends AbstractVaultKeyVal
 
 	VaultKeyValueTemplateVersionedIntegrationTests() {
 		super("versioned", KeyValueBackend.versioned());
+	}
+
+	@Test
+	void shouldPatchSecret() {
+		final String oldKey = "key";
+		final String newKey = "newKey";
+		Map<String, String> secret = Collections.singletonMap(oldKey, "value");
+
+		String key = UUID.randomUUID().toString();
+
+		this.kvOperations.put(key, secret);
+
+		Map<String, String> newSecret = Collections.singletonMap(newKey, "newValue");
+
+		assertTrue(this.kvOperations.patch(key, newSecret));
+
+		assertThat(this.kvOperations.list("/")).contains(key);
+		VaultResponse vaultResponse = this.kvOperations.get(key);
+		assertNotNull(vaultResponse);
+		Map<String, Object> data = vaultResponse.getData();
+		assertNotNull(data);
+		assertThat(data).containsKey(oldKey);
+		assertThat(data).containsKey(newKey);
 	}
 
 }


### PR DESCRIPTION
# Issue Link
[Support for KV Patch in VaultTemplate #585](https://github.com/spring-projects/spring-vault/issues/585)

# Motivation and Context 
This change will enable the support of KV patch operation in VaultKeyValue2Template.
Note that this command will only work with Vault Secret Engine V2.
During the change, I tweaked a doRead() method to get the metadata properly in V2 access which is required to perform patch operation.
Please feel free to suggest improvement of this code. I tried the minimum change so it may have a room to refactor.
This change is based on the source code of the vault CLI:
https://github.com/hashicorp/vault/blob/master/command/kv_patch.go#L66

# How to test this change
Performing mvn install

# Test Evidence
Please see the attached screenshot
![Screen Shot 2020-09-24 at 12 52 04 AM](https://user-images.githubusercontent.com/5394800/94117449-104b1580-fe01-11ea-84f8-ebe662e2988f.png)
