### PR TITLE
Enabled Vault clients to revoke leases using the revoke-prefix endpoint

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
@@ -44,13 +44,22 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			revokeUsing("sys/revoke", lease, operations);
+			operations.exchange("sys/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
+					lease.getLeaseId());
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public Lease renew(Lease lease, RestOperations operations) {
 
-			return renewUsing("sys/renew", lease, operations);
+			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
+
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/renew", HttpMethod.PUT,
+					leaseRenewalEntity, Map.class);
+
+			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
+
+			return toLease(entity.getBody());
 		}
 	},
 
@@ -64,13 +73,22 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			Leases.revoke(lease, operations);
+			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
+					lease.getLeaseId());
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public Lease renew(Lease lease, RestOperations operations) {
 
-			return Leases.renew(lease, operations);
+			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
+
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
+					leaseRenewalEntity, Map.class);
+
+			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
+
+			return toLease(entity.getBody());
 		}
 	},
 
@@ -83,13 +101,22 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			revokeUsing("sys/leases/revoke", lease, operations);
+			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
+					lease.getLeaseId());
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public Lease renew(Lease lease, RestOperations operations) {
 
-			return renewUsing("sys/leases/renew", lease, operations);
+			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
+
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
+					leaseRenewalEntity, Map.class);
+
+			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
+
+			return toLease(entity.getBody());
 		}
 	},
 
@@ -102,13 +129,22 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			revokeUsingPrefixEndpoint(lease, operations);
+			String endpoint = "sys/leases/revoke-prefix/" + lease.getLeaseId();
+			operations.put(endpoint, null);
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public Lease renew(Lease lease, RestOperations operations) {
 
-			return renewUsing("sys/leases/renew", lease, operations);
+			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
+
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
+					leaseRenewalEntity, Map.class);
+
+			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
+
+			return toLease(entity.getBody());
 		}
 	};
 
@@ -126,31 +162,6 @@ public enum LeaseEndpoints {
 	 * @return the renewed {@link Lease}.
 	 */
 	abstract Lease renew(Lease lease, RestOperations operations);
-
-	private static void revokeUsing(String endpoint, Lease lease, RestOperations operations) {
-
-		operations.exchange(endpoint, HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
-				lease.getLeaseId());
-	}
-
-	private static void revokeUsingPrefixEndpoint(Lease lease, RestOperations operations) {
-
-		String endpoint = "sys/leases/revoke-prefix/" + lease.getLeaseId();
-		operations.put(endpoint, null);
-	}
-
-	@SuppressWarnings("unchecked")
-	private static Lease renewUsing(String endpoint, Lease lease, RestOperations operations) {
-
-		HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
-
-		ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange(endpoint, HttpMethod.PUT,
-				leaseRenewalEntity, Map.class);
-
-		Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
-
-		return toLease(entity.getBody());
-	}
 
 	private static Lease toLease(Map<String, Object> body) {
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
@@ -63,6 +63,25 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
+			Leases.revoke(lease, operations);
+		}
+
+		@Override
+		public Lease renew(Lease lease, RestOperations operations) {
+
+			return Leases.renew(lease, operations);
+		}
+	},
+
+	/**
+	 * Sys/lease endpoints for Vault 0.8 and higher ({@literal /sys/leases/…}) that uses
+	 * the {@literal /sys/leases/revoke} endpoint when revoking leases.
+	 */
+	Leases {
+
+		@Override
+		public void revoke(Lease lease, RestOperations operations) {
+
 			revokeUsing("sys/leases/revoke", lease, operations);
 		}
 
@@ -77,7 +96,7 @@ public enum LeaseEndpoints {
 	 * Sys/lease endpoints for Vault 0.8 and higher ({@literal /sys/leases/…}) that uses
 	 * the {@literal /sys/leases/revoke-prefix/…} endpoint when revoking leases.
 	 */
-	SysLeasesUsingRevokePrefix {
+	LeasesRevokedByPrefix {
 
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
@@ -48,14 +48,14 @@ public enum LeaseEndpoints {
 					lease.getLeaseId());
 		}
 
-		@Override
 		@SuppressWarnings("unchecked")
+		@Override
 		public Lease renew(Lease lease, RestOperations operations) {
 
 			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
 
-			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/renew", HttpMethod.PUT,
-					leaseRenewalEntity, Map.class);
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/renew",
+					HttpMethod.PUT, leaseRenewalEntity, Map.class);
 
 			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
 
@@ -73,8 +73,8 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
-					lease.getLeaseId());
+			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease),
+					Map.class, lease.getLeaseId());
 		}
 
 		@Override
@@ -83,8 +83,8 @@ public enum LeaseEndpoints {
 
 			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
 
-			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
-					leaseRenewalEntity, Map.class);
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew",
+					HttpMethod.PUT, leaseRenewalEntity, Map.class);
 
 			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
 
@@ -101,8 +101,8 @@ public enum LeaseEndpoints {
 		@Override
 		public void revoke(Lease lease, RestOperations operations) {
 
-			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease), Map.class,
-					lease.getLeaseId());
+			operations.exchange("sys/leases/revoke", HttpMethod.PUT, LeaseEndpoints.getLeaseRevocationBody(lease),
+					Map.class, lease.getLeaseId());
 		}
 
 		@Override
@@ -111,8 +111,8 @@ public enum LeaseEndpoints {
 
 			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
 
-			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
-					leaseRenewalEntity, Map.class);
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew",
+					HttpMethod.PUT, leaseRenewalEntity, Map.class);
 
 			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
 
@@ -139,8 +139,8 @@ public enum LeaseEndpoints {
 
 			HttpEntity<Object> leaseRenewalEntity = getLeaseRenewalBody(lease);
 
-			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew", HttpMethod.PUT,
-					leaseRenewalEntity, Map.class);
+			ResponseEntity<Map<String, Object>> entity = (ResponseEntity) operations.exchange("sys/leases/renew",
+					HttpMethod.PUT, leaseRenewalEntity, Map.class);
 
 			Assert.state(entity != null && entity.getBody() != null, "Renew response must not be null");
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/LeaseEndpoints.java
@@ -55,9 +55,10 @@ public enum LeaseEndpoints {
 	},
 
 	/**
-	 * Sys/lease endpoints for Vault 0.8 and higher ({@literal /sys/leases/…}) that uses
-	 * the {@literal /sys/leases/revoke} endpoint when revoking leases.
+	 * Alias for {@link #Leases}.
+	 * @deprecated since 2.3, use {@link #Leases} instead.
 	 */
+	@Deprecated
 	SysLeases {
 
 		@Override

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/lease/LeaseEndpointsUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/lease/LeaseEndpointsUnitTests.java
@@ -1,0 +1,230 @@
+package org.springframework.vault.core.lease;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.vault.core.lease.domain.Lease;
+import org.springframework.web.client.RestOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LeaseEndpointsUnitTests {
+
+	@Mock
+	Lease oldLease;
+
+	@Mock
+	RestOperations restOperations;
+
+	@Captor
+	ArgumentCaptor<HttpEntity<Map<String, String>>> httpEntityCaptor;
+
+	@Test
+	@DisplayName("LeaseEndpoints.Legacy uses PUT /sys/renew to renew a lease")
+	void legacyRenewsUsingSysRenew() {
+
+		Map<String, Object> vaultResponseBody = new HashMap<>();
+		vaultResponseBody.put("lease_id", "new_lease");
+		vaultResponseBody.put("lease_duration", 90L);
+		vaultResponseBody.put("renewable", false);
+		when(restOperations.exchange(eq("sys/renew"), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(vaultResponseBody, HttpStatus.OK));
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+		when(oldLease.getLeaseDuration()).thenReturn(Duration.ofSeconds(70));
+
+		Lease renewedLease = LeaseEndpoints.Legacy.renew(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/renew"), eq(HttpMethod.PUT), httpEntityCaptor.capture(), eq(Map.class));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(
+				entry("lease_id", "old_lease"),
+				entry("increment", "70"));
+
+		assertThat(renewedLease.getLeaseId()).isEqualTo("new_lease");
+		assertThat(renewedLease.getLeaseDuration()).isEqualTo(Duration.ofSeconds(90));
+		assertThat(renewedLease.isRenewable()).isFalse();
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@DisplayName("LeaseEndpoints.Legacy uses PUT /sys/revoke to revoke a lease")
+	void legacyRevokesUsingSysRevoke() {
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+
+		LeaseEndpoints.Legacy.revoke(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/revoke"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class), eq("old_lease"));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(entry("lease_id", "old_lease"));
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	@DisplayName("LeaseEndpoints.SysLeases uses PUT /sys/leases/renew to renew a lease")
+	void sysLeasesRenewsUsingSysLeasesRenew() {
+
+		Map<String, Object> vaultResponseBody = new HashMap<>();
+		vaultResponseBody.put("lease_id", "new_lease");
+		vaultResponseBody.put("lease_duration", 90L);
+		vaultResponseBody.put("renewable", false);
+		when(restOperations.exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(vaultResponseBody, HttpStatus.OK));
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+		when(oldLease.getLeaseDuration()).thenReturn(Duration.ofSeconds(70));
+
+		Lease renewedLease = LeaseEndpoints.SysLeases.renew(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(
+				entry("lease_id", "old_lease"),
+				entry("increment", "70"));
+
+		assertThat(renewedLease.getLeaseId()).isEqualTo("new_lease");
+		assertThat(renewedLease.getLeaseDuration()).isEqualTo(Duration.ofSeconds(90));
+		assertThat(renewedLease.isRenewable()).isFalse();
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	@DisplayName("LeaseEndpoints.SysLeases uses PUT /sys/leases/revoke to revoke a lease")
+	void sysLeasesRevokesUsingSysLeasesRevoke() {
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+
+		LeaseEndpoints.SysLeases.revoke(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/leases/revoke"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class), eq("old_lease"));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(entry("lease_id", "old_lease"));
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@DisplayName("LeaseEndpoints.Leases uses PUT /sys/leases/renew to renew a lease")
+	void leasesRenewsUsingSysLeasesRenew() {
+
+		Map<String, Object> vaultResponseBody = new HashMap<>();
+		vaultResponseBody.put("lease_id", "new_lease");
+		vaultResponseBody.put("lease_duration", 90L);
+		vaultResponseBody.put("renewable", false);
+		when(restOperations.exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(vaultResponseBody, HttpStatus.OK));
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+		when(oldLease.getLeaseDuration()).thenReturn(Duration.ofSeconds(70));
+
+		Lease renewedLease = LeaseEndpoints.Leases.renew(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(
+				entry("lease_id", "old_lease"),
+				entry("increment", "70"));
+
+		assertThat(renewedLease.getLeaseId()).isEqualTo("new_lease");
+		assertThat(renewedLease.getLeaseDuration()).isEqualTo(Duration.ofSeconds(90));
+		assertThat(renewedLease.isRenewable()).isFalse();
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@DisplayName("LeaseEndpoints.Leases uses PUT /sys/leases/revoke to revoke a lease")
+	void leasesRevokesUsingSysLeasesRevoke() {
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+
+		LeaseEndpoints.Leases.revoke(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/leases/revoke"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class), eq("old_lease"));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(entry("lease_id", "old_lease"));
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@DisplayName("LeaseEndpoints.LeasesRevokedByPrefix uses PUT /sys/leases/renew to renew a lease")
+	void leasesRevokedByPrefixRenewsUsingSysLeasesRenew() {
+
+		Map<String, Object> vaultResponseBody = new HashMap<>();
+		vaultResponseBody.put("lease_id", "new_lease");
+		vaultResponseBody.put("lease_duration", 90L);
+		vaultResponseBody.put("renewable", false);
+		when(restOperations.exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), any(HttpEntity.class), eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(vaultResponseBody, HttpStatus.OK));
+
+		when(oldLease.getLeaseId()).thenReturn("old_lease");
+		when(oldLease.getLeaseDuration()).thenReturn(Duration.ofSeconds(70));
+
+		Lease renewedLease = LeaseEndpoints.LeasesRevokedByPrefix.renew(oldLease, restOperations);
+
+		verify(restOperations).exchange(eq("sys/leases/renew"), eq(HttpMethod.PUT), httpEntityCaptor.capture(),
+				eq(Map.class));
+
+		Map<String, String> actualRequestBodyParams = httpEntityCaptor.getValue().getBody();
+		assertThat(actualRequestBodyParams).containsOnly(
+				entry("lease_id", "old_lease"),
+				entry("increment", "70"));
+
+		assertThat(renewedLease.getLeaseId()).isEqualTo("new_lease");
+		assertThat(renewedLease.getLeaseDuration()).isEqualTo(Duration.ofSeconds(90));
+		assertThat(renewedLease.isRenewable()).isFalse();
+
+		verifyNoMoreInteractions(restOperations);
+	}
+
+	@Test
+	@DisplayName("LeaseEndpoints.LeasesRevokedByPrefix uses PUT /sys/leases/revoke-prefix/{prefix} to revoke a lease")
+	void leasesRevokedByPrefixRevokesUsingSysLeasesRevokePrefix() {
+
+		when(oldLease.getLeaseId()).thenReturn("my/old/lease");
+
+		LeaseEndpoints.LeasesRevokedByPrefix.revoke(oldLease, restOperations);
+
+		verify(restOperations).put("sys/leases/revoke-prefix/my/old/lease", null);
+
+		verifyNoMoreInteractions(restOperations);
+	}
+}

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/lease/SecretLeaseContainerUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/lease/SecretLeaseContainerUnitTests.java
@@ -58,8 +58,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -118,7 +118,7 @@ class SecretLeaseContainerUnitTests {
 
 		this.secretLeaseContainer.start();
 
-		verifyZeroInteractions(this.leaseListenerAdapter);
+		verifyNoInteractions(this.leaseListenerAdapter);
 	}
 
 	@Test
@@ -143,7 +143,7 @@ class SecretLeaseContainerUnitTests {
 		this.secretLeaseContainer.addRequestedSecret(this.requestedSecret);
 		this.secretLeaseContainer.start();
 
-		verifyZeroInteractions(this.taskScheduler);
+		verifyNoInteractions(this.taskScheduler);
 		verify(this.leaseListenerAdapter).onLeaseEvent(this.captor.capture());
 
 		SecretLeaseCreatedEvent leaseCreatedEvent = (SecretLeaseCreatedEvent) this.captor.getValue();
@@ -166,7 +166,7 @@ class SecretLeaseContainerUnitTests {
 		this.secretLeaseContainer.addRequestedSecret(this.requestedSecret);
 		this.secretLeaseContainer.start();
 
-		verifyZeroInteractions(this.taskScheduler);
+		verifyNoInteractions(this.taskScheduler);
 		verify(this.leaseListenerAdapter).onLeaseEvent(this.captor.capture());
 
 		SecretLeaseCreatedEvent leaseCreatedEvent = (SecretLeaseCreatedEvent) this.captor.getValue();
@@ -224,7 +224,7 @@ class SecretLeaseContainerUnitTests {
 		verify(this.taskScheduler).schedule(captor.capture(), any(Trigger.class));
 
 		captor.getValue().run();
-		verifyZeroInteractions(this.scheduledFuture);
+		verifyNoInteractions(this.scheduledFuture);
 		verify(this.taskScheduler, times(2)).schedule(captor.capture(), any(Trigger.class));
 	}
 
@@ -352,7 +352,7 @@ class SecretLeaseContainerUnitTests {
 		verify(this.taskScheduler).schedule(captor.capture(), any(Trigger.class));
 
 		captor.getValue().run();
-		verifyZeroInteractions(this.scheduledFuture);
+		verifyNoInteractions(this.scheduledFuture);
 		verify(this.taskScheduler, times(2)).schedule(captor.capture(), any(Trigger.class));
 
 		ArgumentCaptor<SecretLeaseEvent> createdEvents = ArgumentCaptor.forClass(SecretLeaseEvent.class);
@@ -406,7 +406,7 @@ class SecretLeaseContainerUnitTests {
 		verify(this.taskScheduler).schedule(captor.capture(), any(Trigger.class));
 
 		captor.getValue().run();
-		verifyZeroInteractions(this.scheduledFuture);
+		verifyNoInteractions(this.scheduledFuture);
 		verify(this.taskScheduler, times(1)).schedule(captor.capture(), any(Trigger.class));
 		verify(this.leaseListenerAdapter).onLeaseEvent(any(SecretLeaseCreatedEvent.class));
 		verify(this.leaseListenerAdapter).onLeaseEvent(any(SecretLeaseExpiredEvent.class));
@@ -598,7 +598,7 @@ class SecretLeaseContainerUnitTests {
 
 		this.secretLeaseContainer.destroy();
 
-		verifyZeroInteractions(this.taskScheduler);
+		verifyNoInteractions(this.taskScheduler);
 
 		verify(this.leaseListenerAdapter, never()).onLeaseEvent(any(BeforeSecretLeaseRevocationEvent.class));
 		verify(this.leaseListenerAdapter, never()).onLeaseEvent(any(AfterSecretLeaseRevocationEvent.class));


### PR DESCRIPTION
Changes made to `LeaseEndpoints`:

- Added `LeasesRevokedByPrefix` which uses the `/sys/leases/revoke-prefix/{prefix}` endpoint when revoking leases
- Added `Leases` which work just like `SysLeases`, ie. it uses the `/sys/leases/revoke` endpoint when revoking leases
- Deprecated `SysLeases` in favour of `Leases`
- Did various refactoring to reduce the amount of code duplication

Closes #588.