### PR TITLE
Added option to specify certificate format

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
@@ -88,8 +88,6 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 	private <T> T requestCertificate(String roleName, String requestPath, Map<String, Object> request,
 			Class<T> responseType) {
 
-		request.put("format", "der");
-
 		T response = this.vaultOperations.doWithSession(restOperations -> {
 
 			try {
@@ -177,6 +175,8 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 		if (certificateRequest.getTtl() != null) {
 			request.put("ttl", certificateRequest.getTtl().get(ChronoUnit.SECONDS));
 		}
+
+		request.put("format", certificateRequest.getFormat().toString());
 
 		if (certificateRequest.isExcludeCommonNameFromSubjectAltNames()) {
 			request.put("exclude_cn_from_sans", true);


### PR DESCRIPTION
When issuing certificates or signing CSRs, the format was hard-coded to "der".
This pull request introduces a way to specify a different format, e.g. "pem".