### PR TITLE
Add support for retries

### DIFF
--- a/spring-vault-core/pom.xml
+++ b/spring-vault-core/pom.xml
@@ -207,6 +207,12 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Testing -->
 
 		<dependency>

--- a/spring-vault-dependencies/pom.xml
+++ b/spring-vault-dependencies/pom.xml
@@ -67,7 +67,7 @@
 		<google-api-services-iam.version>v1-rev20201112-1.31.0</google-api-services-iam.version>
 		<google-auth-library-oauth2-http.version>0.22.2</google-auth-library-oauth2-http.version>
 		<bcpkix-jdk15on.version>1.67</bcpkix-jdk15on.version>
-		<spring-retry.version>1.3.0.RELEASE</spring-retry.version>
+		<spring-retry.version>1.3.0</spring-retry.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-vault-dependencies/pom.xml
+++ b/spring-vault-dependencies/pom.xml
@@ -67,6 +67,7 @@
 		<google-api-services-iam.version>v1-rev20201112-1.31.0</google-api-services-iam.version>
 		<google-auth-library-oauth2-http.version>0.22.2</google-auth-library-oauth2-http.version>
 		<bcpkix-jdk15on.version>1.67</bcpkix-jdk15on.version>
+		<spring-retry.version>1.3.0.RELEASE</spring-retry.version>
 	</properties>
 
 	<dependencyManagement>
@@ -157,6 +158,15 @@
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bcpkix-jdk15on</artifactId>
 				<version>${bcpkix-jdk15on.version}</version>
+				<optional>true</optional>
+			</dependency>
+
+			<!-- Spring Retry -->
+
+			<dependency>
+				<groupId>org.springframework.retry</groupId>
+				<artifactId>spring-retry</artifactId>
+				<version>${spring-retry.version}</version>
 				<optional>true</optional>
 			</dependency>
 


### PR DESCRIPTION
Fixes #504.

This is just an initial draft to get feedback. There's no tests and it only has the retry in one (doWithSession) of several methods.

This would then need a second pr for spring cloud vault ([here](https://github.com/spring-cloud/spring-cloud-vault/compare/master...worldtiki:retries)) so that we can use the `spring.cloud.vault.something.retries=3` niceness.

I struggled a bit about where to setup the retry template. Is that setter a good idea? I'm a bit confused about the optional scope of some dependencies too, and even if spring retry is needed or, given how simple this is, we could just wrap this in some loop / try catch and not add extra libraries.