### PR TITLE
Add necessary scope to gcp signjwt call. Fixes 617

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthentication.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthentication.java
@@ -17,6 +17,7 @@ package org.springframework.vault.authentication;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -67,6 +68,8 @@ public class GcpIamAuthentication extends GcpJwtAuthenticationSupport implements
 
 	private static final JsonFactory JSON_FACTORY = new JacksonFactory();
 
+	private static final String SCOPE = "https://www.googleapis.com/auth/iam";
+
 	private final GcpIamAuthenticationOptions options;
 
 	private final HttpTransport httpTransport;
@@ -103,7 +106,7 @@ public class GcpIamAuthentication extends GcpJwtAuthenticationSupport implements
 
 		this.options = options;
 		this.httpTransport = httpTransport;
-		this.credential = options.getCredentialSupplier().get();
+		this.credential = options.getCredentialSupplier().get().createScoped(Collections.singletonList(SCOPE));
 	}
 
 	@Override

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/AzureMsiAuthenticationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/AzureMsiAuthenticationUnitTests.java
@@ -139,8 +139,7 @@ class AzureMsiAuthenticationUnitTests {
 
 	private void expectVmMetadataRequest() {
 
-		this.mockRest
-				.expect(requestTo(AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI))
+		this.mockRest.expect(requestTo(AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI))
 				.andExpect(method(HttpMethod.GET)).andExpect(header("Metadata", "true"))
 				.andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON)
 						.body("{\n" + "  \"compute\": {\n" + "   \"name\": \"vault-client\",\n"
@@ -150,8 +149,7 @@ class AzureMsiAuthenticationUnitTests {
 
 	private void expectVmssMetadataRequest() {
 
-		this.mockRest
-				.expect(requestTo(AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI))
+		this.mockRest.expect(requestTo(AzureMsiAuthenticationOptions.DEFAULT_INSTANCE_METADATA_SERVICE_URI))
 				.andExpect(method(HttpMethod.GET)).andExpect(header("Metadata", "true"))
 				.andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON)
 						.body("{\n" + "  \"compute\": {\n" + "   \"name\": \"vault-client-scale-set_0\",\n"
@@ -170,14 +168,11 @@ class AzureMsiAuthenticationUnitTests {
 
 	private void expectVmLoginRequest() {
 
-		this.mockRest.expect(requestTo("/auth/azure/login"))
-				.andExpect(method(HttpMethod.POST))
-				.andExpect(jsonPath("$.role").value("dev-role"))
-				.andExpect(jsonPath("$.jwt").value("my-token"))
+		this.mockRest.expect(requestTo("/auth/azure/login")).andExpect(method(HttpMethod.POST))
+				.andExpect(jsonPath("$.role").value("dev-role")).andExpect(jsonPath("$.jwt").value("my-token"))
 				.andExpect(jsonPath("$.subscription_id").value("foobar-subscription"))
 				.andExpect(jsonPath("$.resource_group_name").value("vault"))
-				.andExpect(jsonPath("$.vm_name").value("vault-client"))
-				.andExpect(jsonPath("$.vmss_name").value(""))
+				.andExpect(jsonPath("$.vm_name").value("vault-client")).andExpect(jsonPath("$.vmss_name").value(""))
 				.andRespond(withSuccess().contentType(MediaType.APPLICATION_JSON)
 						.body("{" + "\"auth\":{\"client_token\":\"my-token\"}" + "}"));
 	}


### PR DESCRIPTION
As stated in the end of the documentation: https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts/signJwt 1 one of those 2 scopes are necessary to make this call. I tested locally and with the scope it worked. 

I raised another problem on the issue which is that this api will de shut down in July. This PR does not fix that. I will probably open a new one.