### PR TITLE
Add ability to configure client TLS enabled protocol versions and cipher suites via Spring properties

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/client/ClientHttpConnectorFactory.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/client/ClientHttpConnectorFactory.java
@@ -105,6 +105,14 @@ public class ClientHttpConnectorFactory {
 				sslContextBuilder.keyManager(createKeyManagerFactory(sslConfiguration.getKeyStoreConfiguration(),
 						sslConfiguration.getKeyConfiguration()));
 			}
+
+			if (sslConfiguration.getEnabledProtocols() != null) {
+				sslContextBuilder.protocols(sslConfiguration.getEnabledProtocols());
+			}
+
+			if (sslConfiguration.getEnabledCipherSuites() != null) {
+				sslContextBuilder.ciphers(sslConfiguration.getEnabledCipherSuites());
+			}
 		}
 		catch (GeneralSecurityException | IOException e) {
 			throw new IllegalStateException(e);
@@ -187,6 +195,16 @@ public class ClientHttpConnectorFactory {
 
 				if (keyConfiguration.getKeyPassword() != null) {
 					sslContextFactory.setKeyManagerPassword(new String(keyConfiguration.getKeyPassword()));
+				}
+
+				if (sslConfiguration.getEnabledProtocols() != null) {
+					sslContextFactory
+							.setIncludeProtocols(sslConfiguration.getEnabledProtocols().toArray(new String[0]));
+				}
+
+				if (sslConfiguration.getEnabledCipherSuites() != null) {
+					sslContextFactory
+							.setIncludeCipherSuites(sslConfiguration.getEnabledCipherSuites().toArray(new String[0]));
 				}
 
 				return new org.eclipse.jetty.client.HttpClient(sslContextFactory);

--- a/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
@@ -16,10 +16,11 @@
 package org.springframework.vault.config;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -231,7 +232,12 @@ public class EnvironmentVaultConfiguration extends AbstractVaultConfiguration im
 		KeyStoreConfiguration trustStoreConfiguration = getKeyStoreConfiguration("vault.ssl.trust-store",
 				"vault.ssl.trust-store-password", "vault.ssl.trust-store-type");
 
-		return new SslConfiguration(keyStoreConfiguration, trustStoreConfiguration);
+		List<String> enabledProtocols = getList("vault.ssl.enabled-protocols");
+
+		List<String> enabledCipherSuites = getList("vault.ssl.enabled-cipher-suites");
+
+		return new SslConfiguration(keyStoreConfiguration, trustStoreConfiguration, enabledProtocols,
+				enabledCipherSuites);
 	}
 
 	private KeyStoreConfiguration getKeyStoreConfiguration(String resourceProperty, String passwordProperty,
@@ -419,6 +425,16 @@ public class EnvironmentVaultConfiguration extends AbstractVaultConfiguration im
 				.jwtSupplier(jwtSupplier).path(path);
 
 		return new KubernetesAuthentication(builder.build(), restOperations());
+	}
+
+	private List<String> getList(String key) {
+		String val = getEnvironment().getProperty(key);
+
+		if (val == null) {
+			return null;
+		}
+
+		return Arrays.asList(val.split(","));
 	}
 
 	@Nullable

--- a/spring-vault-core/src/test/java/org/springframework/vault/client/ClientHttpConnectorFactoryIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/client/ClientHttpConnectorFactoryIntegrationTests.java
@@ -27,6 +27,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.vault.client.ClientHttpConnectorFactory.JettyClient;
 import static org.springframework.vault.client.ClientHttpConnectorFactory.ReactorNetty;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Integration tests for {@link ClientHttpConnectorFactory}.
  *
@@ -50,9 +53,75 @@ class ClientHttpConnectorFactoryIntegrationTests {
 	}
 
 	@Test
+	void reactorNettyClientWithExplicitEnabledCipherSuitesShouldWork() {
+
+		List<String> enabledCipherSuites = new ArrayList<String>();
+		enabledCipherSuites.add("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
+		enabledCipherSuites.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+
+		ClientHttpConnector factory = ReactorNetty.usingReactorNetty(new ClientOptions(),
+				Settings.createSslConfiguration().withEnabledCipherSuites(enabledCipherSuites));
+
+		WebClient webClient = WebClient.builder().clientConnector(factory).build();
+
+		String response = request(webClient);
+
+		assertThat(response).isNotNull().contains("initialized");
+	}
+
+	@Test
+	void reactorNettyClientWithExplicitEnabledProtocolsShouldWork() {
+
+		List<String> enabledProtocols = new ArrayList<String>();
+		enabledProtocols.add("TLSv1.2");
+
+		ClientHttpConnector factory = ReactorNetty.usingReactorNetty(new ClientOptions(),
+				Settings.createSslConfiguration().withEnabledProtocols(enabledProtocols));
+
+		WebClient webClient = WebClient.builder().clientConnector(factory).build();
+
+		String response = request(webClient);
+
+		assertThat(response).isNotNull().contains("initialized");
+	}
+
+	@Test
 	void jettyClientShouldWork() {
 
 		ClientHttpConnector factory = JettyClient.usingJetty(new ClientOptions(), Settings.createSslConfiguration());
+
+		WebClient webClient = WebClient.builder().clientConnector(factory).build();
+
+		String response = request(webClient);
+
+		assertThat(response).isNotNull().contains("initialized");
+	}
+
+	@Test
+	void jettyClientWithExplicitEnabledCipherSuitesShouldWork() {
+
+		List<String> enabledCipherSuites = new ArrayList<String>();
+		enabledCipherSuites.add("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
+		enabledCipherSuites.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+
+		ClientHttpConnector factory = JettyClient.usingJetty(new ClientOptions(),
+				Settings.createSslConfiguration().withEnabledCipherSuites(enabledCipherSuites));
+
+		WebClient webClient = WebClient.builder().clientConnector(factory).build();
+
+		String response = request(webClient);
+
+		assertThat(response).isNotNull().contains("initialized");
+	}
+
+	@Test
+	void jettyClientWithExplicitEnabledProtocolsShouldWork() {
+
+		List<String> enabledProtocols = new ArrayList<String>();
+		enabledProtocols.add("TLSv1.2");
+
+		ClientHttpConnector factory = JettyClient.usingJetty(new ClientOptions(),
+				Settings.createSslConfiguration().withEnabledProtocols(enabledProtocols));
 
 		WebClient webClient = WebClient.builder().clientConnector(factory).build();
 

--- a/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.vault.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -33,8 +34,6 @@ import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.support.SslConfiguration;
 import org.springframework.vault.support.VaultToken;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link EnvironmentVaultConfiguration}.
@@ -78,6 +77,9 @@ class EnvironmentVaultConfigurationUnitTests {
 		Map<String, Object> map = new HashMap<String, Object>();
 		map.put("vault.ssl.key-store", "classpath:certificate.json");
 		map.put("vault.ssl.trust-store", "classpath:certificate.json");
+		map.put("vault.ssl.enabled-protocols", "TLSv1.2,TLSv1.1");
+		map.put("vault.ssl.enabled-cipher-suites",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
 
 		MapPropertySource propertySource = new MapPropertySource("shouldConfigureSsl", map);
 		this.configurableEnvironment.getPropertySources().addFirst(propertySource);
@@ -89,6 +91,10 @@ class EnvironmentVaultConfigurationUnitTests {
 
 		assertThat(sslConfiguration.getTrustStore()).isInstanceOf(ClassPathResource.class);
 		assertThat(sslConfiguration.getTrustStorePassword()).isEqualTo("trust store password");
+
+		assertThat(sslConfiguration.getEnabledProtocols()).containsExactly("TLSv1.2", "TLSv1.1");
+		assertThat(sslConfiguration.getEnabledCipherSuites()).containsExactly("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
 
 		this.configurableEnvironment.getPropertySources().remove(propertySource.getName());
 	}

--- a/spring-vault-core/src/test/java/org/springframework/vault/support/SslConfigurationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/support/SslConfigurationUnitTests.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.vault.support;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.vault.support.SslConfiguration.KeyStoreConfiguration;
 import org.springframework.vault.util.Settings;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link SslConfiguration}.
@@ -46,6 +47,8 @@ class SslConfigurationUnitTests {
 
 		assertThat(sslConfiguration.getKeyStoreConfiguration().isPresent()).isFalse();
 		assertThat(sslConfiguration.getTrustStoreConfiguration().isPresent()).isFalse();
+		assertThat(sslConfiguration.getEnabledCipherSuites()).isNull();
+		assertThat(sslConfiguration.getEnabledProtocols()).isNull();
 	}
 
 	@Test
@@ -61,6 +64,35 @@ class SslConfigurationUnitTests {
 
 		assertThat(tsConfig.getTrustStoreConfiguration()).isSameAs(keystore);
 		assertThat(tsConfig.getKeyStoreConfiguration().isPresent()).isFalse();
+	}
+
+	@Test
+	void shouldCreateConfigurationWithEnabledCipherSuites() {
+
+		KeyStoreConfiguration keystore = KeyStoreConfiguration.of(new ClassPathResource("certificate.json"));
+		SslConfiguration tsConfig = SslConfiguration.unconfigured().withTrustStore(keystore)
+				.withEnabledCipherSuites(Arrays.asList(new String[] { "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" }));
+
+		assertThat(tsConfig.getTrustStoreConfiguration()).isSameAs(keystore);
+		assertThat(tsConfig.getKeyStoreConfiguration().isPresent()).isFalse();
+		assertThat(tsConfig.getEnabledCipherSuites().size()).isEqualTo(2);
+		assertThat(tsConfig.getEnabledCipherSuites().get(0)).isEqualTo("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
+		assertThat(tsConfig.getEnabledCipherSuites().get(1)).isEqualTo("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+	}
+
+	@Test
+	void shouldCreateConfigurationWithEnabledProtocols() {
+
+		KeyStoreConfiguration keystore = KeyStoreConfiguration.of(new ClassPathResource("certificate.json"));
+		SslConfiguration tsConfig = SslConfiguration.unconfigured().withTrustStore(keystore)
+				.withEnabledProtocols(Arrays.asList(new String[] { "TLSv1.2", "TLSv1.1" }));
+
+		assertThat(tsConfig.getTrustStoreConfiguration()).isSameAs(keystore);
+		assertThat(tsConfig.getKeyStoreConfiguration().isPresent()).isFalse();
+		assertThat(tsConfig.getEnabledProtocols().size()).isEqualTo(2);
+		assertThat(tsConfig.getEnabledProtocols().get(0)).isEqualTo("TLSv1.2");
+		assertThat(tsConfig.getEnabledProtocols().get(1)).isEqualTo("TLSv1.1");
 	}
 
 	@Test


### PR DESCRIPTION
- Adding the ability to explicitly configure the enabled SSL protocol
versions and cipher suites used by the Vault HTTP client via the
following Spring properties:

  * vault.ssl.enabled-protocols
  * vault.ssl.enabled-cipher-suites

- Properties should be a comma-separated list of String constants that
correspond to those used by the enabled SSL provider.

Closes gh-635