### PR TITLE
Bumped Azure IMDS API version

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AzureMsiAuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AzureMsiAuthenticationOptions.java
@@ -38,7 +38,7 @@ public class AzureMsiAuthenticationOptions {
 	public static final String DEFAULT_AZURE_AUTHENTICATION_PATH = "azure";
 
 	public static final URI DEFAULT_INSTANCE_METADATA_SERVICE_URI = URI
-			.create("http://169.254.169.254/metadata/instance?api-version=2017-08-01");
+			.create("http://169.254.169.254/metadata/instance?api-version=2017-12-01");
 
 	public static final URI DEFAULT_IDENTITY_TOKEN_SERVICE_URI = URI.create(
 			"http://169.254.169.254/metadata/identity/oauth2/token?resource=https://vault.hashicorp.com&api-version=2018-02-01");
@@ -194,7 +194,7 @@ public class AzureMsiAuthenticationOptions {
 		 */
 		public AzureMsiAuthenticationOptionsBuilder instanceMetadataUri(URI instanceMetadataServiceUri) {
 
-			Assert.notNull(this.identityTokenServiceUri, "Instance metadata service URI must not be null");
+			Assert.notNull(instanceMetadataServiceUri, "Instance metadata service URI must not be null");
 
 			this.instanceMetadataServiceUri = instanceMetadataServiceUri;
 			return this;


### PR DESCRIPTION
vmScaleSetName is only exposed in 2017-12-01 and later.
See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service\?tabs\=windows\#response-1