### PR TITLE
Fix typos in GCP IAM builders

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamAuthenticationOptions.java
@@ -249,7 +249,7 @@ public class GcpIamAuthenticationOptions extends GcpIamAuthenticationSupport {
 		 */
 		public GcpIamAuthenticationOptionsBuilder jwtValidity(Duration jwtValidity) {
 
-			Assert.hasText(this.role, "JWT validity duration must not be null");
+			Assert.notNull(jwtValidity, "JWT validity duration must not be null");
 
 			this.jwtValidity = jwtValidity;
 			return this;
@@ -263,7 +263,7 @@ public class GcpIamAuthenticationOptions extends GcpIamAuthenticationSupport {
 		 */
 		public GcpIamAuthenticationOptionsBuilder clock(Clock clock) {
 
-			Assert.hasText(this.role, "Clock must not be null");
+			Assert.notNull(clock, "Clock must not be null");
 
 			this.clock = clock;
 			return this;

--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamCredentialsAuthenticationOptions.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/GcpIamCredentialsAuthenticationOptions.java
@@ -200,7 +200,7 @@ public class GcpIamCredentialsAuthenticationOptions extends GcpIamAuthentication
 		 */
 		public GcpIamCredentialsAuthenticationOptionsBuilder jwtValidity(Duration jwtValidity) {
 
-			Assert.hasText(this.role, "JWT validity duration must not be null");
+			Assert.notNull(jwtValidity, "JWT validity duration must not be null");
 
 			this.jwtValidity = jwtValidity;
 			return this;
@@ -214,7 +214,7 @@ public class GcpIamCredentialsAuthenticationOptions extends GcpIamAuthentication
 		 */
 		public GcpIamCredentialsAuthenticationOptionsBuilder clock(Clock clock) {
 
-			Assert.hasText(this.role, "Clock must not be null");
+			Assert.notNull(clock, "Clock must not be null");
 
 			this.clock = clock;
 			return this;


### PR DESCRIPTION
 Fix typos in GcpIamAuthenticationOptions & GcpIamCredentialsAuthenticationOptions.