### PR TITLE
Increase netty version to address security vulnerabilities

### DIFF
--- a/spring-vault-dependencies/pom.xml
+++ b/spring-vault-dependencies/pom.xml
@@ -60,7 +60,7 @@
 		<httpclient.version>4.5.13</httpclient.version>
 		<httpcore.version>4.4.14</httpcore.version>
 		<jetty-reactive-httpclient.version>1.1.6</jetty-reactive-httpclient.version>
-		<netty.version>4.1.60.Final</netty.version>
+		<netty.version>4.1.70.Final</netty.version>
 		<okhttp3.version>3.14.9</okhttp3.version>
 		<jackson-databind.version>2.12.2</jackson-databind.version>
 		<aws-java-sdk.version>1.11.975</aws-java-sdk.version>


### PR DESCRIPTION
Hi team,

Would it be possible to upgrade the netty version to `4.1.70.Final` to address the following security vulnerabilities:

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21409
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37136
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37137

Please let me know if there is anything else that is needed to make the change.

Cheers,
Scott