### PR TITLE
Replace algorithm property in VaultSignRequest/VaultSignatureVerificationRequest

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
@@ -384,8 +384,12 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		Map<String, Object> request = new LinkedHashMap<>();
 		request.put("input", Base64Utils.encodeToString(signRequest.getPlaintext().getPlaintext()));
 
-		if (StringUtils.hasText(signRequest.getAlgorithm())) {
-			request.put("algorithm", signRequest.getAlgorithm());
+		if (StringUtils.hasText(signRequest.getHashAlgorithm())) {
+			request.put("hash_algorithm", signRequest.getHashAlgorithm());
+		}
+
+		if (StringUtils.hasText(signRequest.getSignatureAlgorithm())) {
+			request.put("signature_algorithm", signRequest.getSignatureAlgorithm());
 		}
 
 		String signature = (String) this.vaultOperations.write(String.format("%s/sign/%s", this.path, keyName), request)
@@ -422,8 +426,12 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 			request.put("signature", verificationRequest.getSignature().getSignature());
 		}
 
-		if (StringUtils.hasText(verificationRequest.getAlgorithm())) {
-			request.put("algorithm", verificationRequest.getAlgorithm());
+		if (StringUtils.hasText(verificationRequest.getHashAlgorithm())) {
+			request.put("hash_algorithm", verificationRequest.getHashAlgorithm());
+		}
+
+		if (StringUtils.hasText(verificationRequest.getSignatureAlgorithm())) {
+			request.put("signature_algorithm", verificationRequest.getSignatureAlgorithm());
 		}
 
 		Map<String, Object> response = this.vaultOperations

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultSignRequest.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultSignRequest.java
@@ -29,12 +29,15 @@ public class VaultSignRequest {
 
 	private final Plaintext plaintext;
 
-	private final @Nullable String algorithm;
+	private final @Nullable String hashAlgorithm;
 
-	private VaultSignRequest(Plaintext plaintext, @Nullable String algorithm) {
+	private final @Nullable String signatureAlgorithm;
+
+	private VaultSignRequest(Plaintext plaintext, @Nullable String hashAlgorithm, @Nullable String signatureAlgorithm) {
 
 		this.plaintext = plaintext;
-		this.algorithm = algorithm;
+		this.hashAlgorithm = hashAlgorithm;
+		this.signatureAlgorithm = signatureAlgorithm;
 	}
 
 	/**
@@ -61,12 +64,21 @@ public class VaultSignRequest {
 	}
 
 	/**
-	 * @return algorithm used for creating the signature or {@literal null} to use the
-	 * default algorithm.
+	 * @return hashAlgorithm used for creating the signature or {@literal null} to use the
+	 * default hash algorithm.
 	 */
 	@Nullable
-	public String getAlgorithm() {
-		return this.algorithm;
+	public String getHashAlgorithm() {
+		return this.hashAlgorithm;
+	}
+
+	/**
+	 * @return signatureAlgorithm used for creating the signature when using a RSA key or
+	 * {@literal null} to use the default signature algorithm.
+	 */
+	@Nullable
+	public String getSignatureAlgorithm() {
+		return this.signatureAlgorithm;
 	}
 
 	/**
@@ -76,7 +88,9 @@ public class VaultSignRequest {
 
 		private @Nullable Plaintext plaintext;
 
-		private @Nullable String algorithm;
+		private @Nullable String hashAlgorithm;
+
+		private @Nullable String signatureAlgorithm;
 
 		/**
 		 * Configure the input to be used to create the signature.
@@ -92,17 +106,34 @@ public class VaultSignRequest {
 		}
 
 		/**
-		 * Configure the algorithm to be used for the operation.
-		 * @param algorithm Specify the algorithm to be used for the operation. Supported
-		 * algorithms are: {@literal sha2-224}, {@literal sha2-256}, {@literal sha2-384},
-		 * {@literal sha2-512}. Defaults to {@literal sha2-256} if not set.
+		 * Configure the hash algorithm to be used for the operation.
+		 * @param hashAlgorithm Specify the hash algorithm to be used for the operation.
+		 * Supported algorithms are: {@literal sha1}, {@literal sha2-224},
+		 * {@literal sha2-256}, {@literal sha2-384}, {@literal sha2-512}. Defaults to
+		 * {@literal sha2-256} if not set.
 		 * @return {@code this} {@link VaultSignRequestBuilder}.
 		 */
-		public VaultSignRequestBuilder algorithm(String algorithm) {
+		public VaultSignRequestBuilder hashAlgorithm(String hashAlgorithm) {
 
-			Assert.hasText(algorithm, "Algorithm must not be null or empty");
+			Assert.hasText(hashAlgorithm, "Hash algorithm must not be null or empty");
 
-			this.algorithm = algorithm;
+			this.hashAlgorithm = hashAlgorithm;
+			return this;
+		}
+
+		/**
+		 * Configure the signature algorithm to be used for the operation when using a RSA
+		 * key.
+		 * @param signatureAlgorithm Specify the signature algorithm to be used for the
+		 * operation. Supported algorithms are: {@literal pss}, {@literal pkcs1v15}.
+		 * Defaults to {@literal pss} if not set.
+		 * @return {@code this} {@link VaultSignRequestBuilder}.
+		 */
+		public VaultSignRequestBuilder signatureAlgorithm(String signatureAlgorithm) {
+
+			Assert.hasText(signatureAlgorithm, "Hash algorithm must not be null or empty");
+
+			this.signatureAlgorithm = signatureAlgorithm;
 			return this;
 		}
 
@@ -115,7 +146,7 @@ public class VaultSignRequest {
 
 			Assert.notNull(this.plaintext, "Plaintext input must not be null");
 
-			return new VaultSignRequest(this.plaintext, this.algorithm);
+			return new VaultSignRequest(this.plaintext, this.hashAlgorithm, this.signatureAlgorithm);
 		}
 
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultSignatureVerificationRequest.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultSignatureVerificationRequest.java
@@ -33,15 +33,18 @@ public class VaultSignatureVerificationRequest {
 
 	private final @Nullable Hmac hmac;
 
-	private final @Nullable String algorithm;
+	private final @Nullable String hashAlgorithm;
+
+	private final @Nullable String signatureAlgorithm;
 
 	private VaultSignatureVerificationRequest(Plaintext plaintext, @Nullable Signature signature, @Nullable Hmac hmac,
-			@Nullable String algorithm) {
+			@Nullable String hashAlgorithm, @Nullable String signatureAlgorithm) {
 
 		this.plaintext = plaintext;
 		this.signature = signature;
 		this.hmac = hmac;
-		this.algorithm = algorithm;
+		this.hashAlgorithm = hashAlgorithm;
+		this.signatureAlgorithm = signatureAlgorithm;
 	}
 
 	/**
@@ -101,12 +104,21 @@ public class VaultSignatureVerificationRequest {
 	}
 
 	/**
-	 * @return algorithm used for verifying the signature or {@literal null} to use the
-	 * default algorithm.
+	 * @return hash algorithm used for verifying the signature or {@literal null} to use
+	 * the default algorithm.
 	 */
 	@Nullable
-	public String getAlgorithm() {
-		return this.algorithm;
+	public String getHashAlgorithm() {
+		return this.hashAlgorithm;
+	}
+
+	/**
+	 * @return signature algorithm used for verifying the signature when using a RSA key
+	 * or {@literal null} to use the default algorithm.
+	 */
+	@Nullable
+	public String getSignatureAlgorithm() {
+		return this.signatureAlgorithm;
 	}
 
 	/**
@@ -120,7 +132,9 @@ public class VaultSignatureVerificationRequest {
 
 		private @Nullable Hmac hmac;
 
-		private @Nullable String algorithm;
+		private @Nullable String hashAlgorithm;
+
+		private @Nullable String signatureAlgorithm;
 
 		/**
 		 * Configure the {@link Plaintext} input to be used to verify the signature.
@@ -168,17 +182,34 @@ public class VaultSignatureVerificationRequest {
 		}
 
 		/**
-		 * Configure the algorithm to be used for the operation.
-		 * @param algorithm Specify the algorithm to be used for the operation. Supported
-		 * algorithms are: {@literal sha2-224}, {@literal sha2-256}, {@literal sha2-384},
-		 * {@literal sha2-512}. Defaults to {@literal sha2-256} if not set.
+		 * Configure the hash algorithm to be used for the operation.
+		 * @param hashAlgorithm Specify the hash algorithm to be used for the operation.
+		 * Supported algorithms are: {@literal sha1}, {@literal sha2-224},
+		 * {@literal sha2-256}, {@literal sha2-384}, {@literal sha2-512}. Defaults to
+		 * {@literal sha2-256} if not set.
 		 * @return {@code this} {@link VaultSignatureVerificationRequestBuilder}.
 		 */
-		public VaultSignatureVerificationRequestBuilder algorithm(String algorithm) {
+		public VaultSignatureVerificationRequestBuilder hashAlgorithm(String hashAlgorithm) {
 
-			Assert.hasText(algorithm, "Algorithm must not be null or empty");
+			Assert.hasText(hashAlgorithm, "Hash algorithm must not be null or empty");
 
-			this.algorithm = algorithm;
+			this.hashAlgorithm = hashAlgorithm;
+			return this;
+		}
+
+		/**
+		 * Configure the signature algorithm to be used for the operation when using a RSA
+		 * key.
+		 * @param signatureAlgorithm Specify the signature algorithm to be used for the
+		 * operation. Supported algorithms are: {@literal pss}, {@literal pkcs1v15}.
+		 * Defaults to {@literal pss} if not set.
+		 * @return {@code this} {@link VaultSignatureVerificationRequestBuilder}.
+		 */
+		public VaultSignatureVerificationRequestBuilder signatureAlgorithm(String signatureAlgorithm) {
+
+			Assert.hasText(signatureAlgorithm, "Signature algorithm must not be null or empty");
+
+			this.signatureAlgorithm = signatureAlgorithm;
 			return this;
 		}
 
@@ -193,7 +224,8 @@ public class VaultSignatureVerificationRequest {
 			Assert.notNull(this.input, "Plaintext input must not be null");
 			Assert.isTrue(this.hmac != null || this.signature != null, "Either Signature or Hmac must not be null");
 
-			return new VaultSignatureVerificationRequest(this.input, this.signature, this.hmac, this.algorithm);
+			return new VaultSignatureVerificationRequest(this.input, this.signature, this.hmac, this.hashAlgorithm,
+					this.signatureAlgorithm);
 		}
 
 	}

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
@@ -683,7 +683,7 @@ class VaultTransitTemplateIntegrationTests extends IntegrationTestSupport {
 		String keyName = createEcdsaP256Key();
 
 		Plaintext plaintext = Plaintext.of("hello-world");
-		VaultSignRequest request = VaultSignRequest.builder().plaintext(plaintext).algorithm("sha2-512").build();
+		VaultSignRequest request = VaultSignRequest.builder().plaintext(plaintext).hashAlgorithm("sha2-512").build();
 
 		Signature signature = this.transitOperations.sign(keyName, request);
 		assertThat(signature.getSignature()).isNotEmpty();
@@ -723,12 +723,12 @@ class VaultTransitTemplateIntegrationTests extends IntegrationTestSupport {
 		String keyName = createEcdsaP256Key();
 
 		Plaintext plaintext = Plaintext.of("hello-world");
-		VaultSignRequest request = VaultSignRequest.builder().plaintext(plaintext).algorithm("sha2-512").build();
+		VaultSignRequest request = VaultSignRequest.builder().plaintext(plaintext).hashAlgorithm("sha2-512").build();
 
 		Signature signature = this.transitOperations.sign(keyName, request);
 
 		VaultSignatureVerificationRequest verificationRequest = VaultSignatureVerificationRequest.builder()
-				.algorithm("sha2-512").plaintext(plaintext).signature(signature).build();
+				.hashAlgorithm("sha2-512").plaintext(plaintext).signature(signature).build();
 
 		SignatureValidation valid = this.transitOperations.verify(keyName, verificationRequest);
 		assertThat(valid).isEqualTo(SignatureValidation.valid());


### PR DESCRIPTION
Based on [https://www.vaultproject.io/api/secret/transit#sign-data](url) and [https://www.vaultproject.io/api/secret/transit#verify-signed-data](url), algorithm property does no longer exist and was replaced by hash_algorithm. When using a RSA key signature_algorithm is also used.

Replace algorithm property with hashAlgorithm and signatureAlgorithm in VaultSignRequest and VaultSignatureVerificationRequest and update mapping in `VaultTransitTemplate.sign()` and `VaultTransitTemplate.verify()` 