### PR TITLE
Extend VaultTransitKey with additional properties returned by the API

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
@@ -16,8 +16,6 @@
 package org.springframework.vault.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jetbrains.annotations.NotNull;
-
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -598,6 +596,9 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@JsonProperty("supports_signing")
 		private boolean supportsSigning;
 
+		@JsonProperty("allow_plaintext_backup")
+		private boolean allowPlaintextBackup;
+
 		public VaultTransitKeyImpl() {
 		}
 
@@ -629,6 +630,11 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@Override
 		public boolean supportsSigning() {
 			return isSupportsSigning();
+		}
+
+		@Override
+		public boolean allowPlaintextBackup() {
+			return isAllowPlaintextBackup();
 		}
 
 		@Nullable
@@ -666,6 +672,10 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 
 		public int getMinEncryptionVersion() {
 			return this.minEncryptionVersion;
+		}
+
+		public boolean isAllowPlaintextBackup() {
+			return this.allowPlaintextBackup;
 		}
 
 		public boolean isSupportsDecryption() {
@@ -756,7 +766,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 					&& this.supportsDerivation == that.supportsDerivation
 					&& this.supportsSigning == that.supportsSigning && Objects.equals(this.name, that.name)
 					&& this.cipherMode.equals(that.cipherMode) && Objects.equals(this.type, that.type)
-					&& this.keys.equals(that.keys);
+					&& this.allowPlaintextBackup == that.allowPlaintextBackup;
 		}
 
 		@Override
@@ -764,7 +774,7 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 			return Objects.hash(this.name, this.cipherMode, this.type, this.deletionAllowed, this.derived,
 					this.exportable, this.keys, this.latestVersion, this.minDecryptionVersion,
 					this.minEncryptionVersion, this.supportsDecryption, this.supportsEncryption,
-					this.supportsDerivation, this.supportsSigning);
+					this.supportsDerivation, this.supportsSigning, this.allowPlaintextBackup);
 		}
 
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
@@ -602,6 +602,9 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@JsonProperty("convergent_encryption")
 		private boolean supportsConvergentEncryption;
 
+		@JsonProperty("convergent_encryption_version")
+		private int convergentVersion;
+
 		public VaultTransitKeyImpl() {
 		}
 
@@ -643,6 +646,11 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@Override
 		public boolean supportsConvergentEncryption() {
 			return isSupportsConvergentEncryption();
+		}
+
+		@Override
+		public int getConvergentVersion() {
+			return this.convergentVersion;
 		}
 
 		@Nullable

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultTransitTemplate.java
@@ -599,6 +599,9 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@JsonProperty("allow_plaintext_backup")
 		private boolean allowPlaintextBackup;
 
+		@JsonProperty("convergent_encryption")
+		private boolean supportsConvergentEncryption;
+
 		public VaultTransitKeyImpl() {
 		}
 
@@ -635,6 +638,11 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 		@Override
 		public boolean allowPlaintextBackup() {
 			return isAllowPlaintextBackup();
+		}
+
+		@Override
+		public boolean supportsConvergentEncryption() {
+			return isSupportsConvergentEncryption();
 		}
 
 		@Nullable
@@ -692,6 +700,10 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 
 		public boolean isSupportsSigning() {
 			return this.supportsSigning;
+		}
+
+		public boolean isSupportsConvergentEncryption() {
+			return this.supportsConvergentEncryption;
 		}
 
 		public void setName(@Nullable String name) {
@@ -766,7 +778,8 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 					&& this.supportsDerivation == that.supportsDerivation
 					&& this.supportsSigning == that.supportsSigning && Objects.equals(this.name, that.name)
 					&& this.cipherMode.equals(that.cipherMode) && Objects.equals(this.type, that.type)
-					&& this.allowPlaintextBackup == that.allowPlaintextBackup;
+					&& this.allowPlaintextBackup == that.allowPlaintextBackup
+					&& this.supportsConvergentEncryption == that.supportsConvergentEncryption;
 		}
 
 		@Override
@@ -774,7 +787,8 @@ public class VaultTransitTemplate implements VaultTransitOperations {
 			return Objects.hash(this.name, this.cipherMode, this.type, this.deletionAllowed, this.derived,
 					this.exportable, this.keys, this.latestVersion, this.minDecryptionVersion,
 					this.minEncryptionVersion, this.supportsDecryption, this.supportsEncryption,
-					this.supportsDerivation, this.supportsSigning, this.allowPlaintextBackup);
+					this.supportsDerivation, this.supportsSigning, this.allowPlaintextBackup,
+					this.supportsConvergentEncryption);
 		}
 
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
@@ -102,4 +102,10 @@ public interface VaultTransitKey {
 	 */
 	boolean allowPlaintextBackup();
 
+	/**
+	 * @return If enabled, the key will support convergent encryption, where the same
+	 * plaintext creates the same ciphertext. This requires 'derived' to be set to true.
+	 */
+	boolean supportsConvergentEncryption();
+
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
@@ -96,4 +96,10 @@ public interface VaultTransitKey {
 	 */
 	boolean supportsSigning();
 
+	/**
+	 * @return if set, enables taking backup of named key in the plaintext format. Once
+	 * set, this cannot be disabled.
+	 */
+	boolean allowPlaintextBackup();
+
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKey.java
@@ -108,4 +108,11 @@ public interface VaultTransitKey {
 	 */
 	boolean supportsConvergentEncryption();
 
+	/**
+	 * @return the version of the convergent nonce to use. Note: since version 3 the
+	 * algorithm used in `transit`'s convergent encryption returns -1 since the version is
+	 * stored with the key. For backwards compatability this field might be interesting.
+	 */
+	int getConvergentVersion();
+
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKeyCreationRequest.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultTransitKeyCreationRequest.java
@@ -37,12 +37,16 @@ public class VaultTransitKeyCreationRequest {
 
 	private final boolean exportable;
 
+	@JsonProperty("allow_plaintext_backup")
+	private final boolean allowPlaintextBackup;
+
 	private VaultTransitKeyCreationRequest(boolean derived, String type, boolean convergentEncryption,
-			boolean exportable) {
+			boolean exportable, boolean allowPlaintextBackup) {
 		this.derived = derived;
 		this.type = type;
 		this.convergentEncryption = convergentEncryption;
 		this.exportable = exportable;
+		this.allowPlaintextBackup = allowPlaintextBackup;
 	}
 
 	/**
@@ -106,6 +110,8 @@ public class VaultTransitKeyCreationRequest {
 
 		private boolean exportable;
 
+		private boolean allowPlaintextBackup;
+
 		VaultTransitKeyCreationRequestBuilder() {
 		}
 
@@ -160,6 +166,12 @@ public class VaultTransitKeyCreationRequest {
 			return this;
 		}
 
+		public VaultTransitKeyCreationRequestBuilder allowPlaintextBackup(boolean allowPlaintextBackup) {
+
+			this.allowPlaintextBackup = allowPlaintextBackup;
+			return this;
+		}
+
 		/**
 		 * Build a new {@link VaultTransitKeyCreationRequest} instance. Requires
 		 * {@link #type(String)} to be configured.
@@ -170,7 +182,7 @@ public class VaultTransitKeyCreationRequest {
 			Assert.hasText(this.type, "Type must not be empty");
 
 			return new VaultTransitKeyCreationRequest(this.derived, this.type, this.convergentEncryption,
-					this.exportable);
+					this.exportable, this.allowPlaintextBackup);
 		}
 
 	}

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
@@ -232,6 +232,7 @@ class VaultTransitTemplateIntegrationTests extends IntegrationTestSupport {
 		assertThat(mykey.isDerived()).isTrue();
 		assertThat(mykey.getMinDecryptionVersion()).isEqualTo(1);
 		assertThat(mykey.getLatestVersion()).isEqualTo(1);
+		assertThat(mykey.supportsConvergentEncryption()).isTrue();
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
@@ -233,6 +233,7 @@ class VaultTransitTemplateIntegrationTests extends IntegrationTestSupport {
 		assertThat(mykey.getMinDecryptionVersion()).isEqualTo(1);
 		assertThat(mykey.getLatestVersion()).isEqualTo(1);
 		assertThat(mykey.supportsConvergentEncryption()).isTrue();
+		assertThat(mykey.getConvergentVersion()).isEqualTo(-1);
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultTransitTemplateIntegrationTests.java
@@ -235,6 +235,20 @@ class VaultTransitTemplateIntegrationTests extends IntegrationTestSupport {
 	}
 
 	@Test
+	void createKeyWithPlaintextBackupOption() {
+		VaultTransitKeyCreationRequest request = VaultTransitKeyCreationRequest.builder() //
+			.allowPlaintextBackup(true) //
+			.build();
+
+		this.transitOperations.createKey("mykey", request);
+
+		VaultTransitKey mykey = this.transitOperations.getKey("mykey");
+
+		assertThat(mykey.getName()).isEqualTo("mykey");
+		assertThat(mykey.allowPlaintextBackup()).isTrue();
+	}
+
+	@Test
 	void shouldConfigureKey() {
 
 		this.transitOperations.createKey("mykey");


### PR DESCRIPTION
Added several properties in the key object, each in a separate commit.
Best reviewed per commit.