### PR TITLE
Update PKI Vault operations

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiOperations.java
@@ -113,9 +113,8 @@ public interface VaultPkiOperations {
 	 * Retrieves the specified issuer's certificate. Includes the full ca_chain of the
 	 * issuer.
 	 * @param issuer reference to an existing issuer, either by Vault-generated
-	 * identifier, or the name assigned to an issuer. If empty or {@literal null}, the
-	 * issuer will default to the literal string default to refer to the currently
-	 * configured default issuer.
+	 * identifier, or the name assigned to an issuer. Pass the literal string 'default' to
+	 * refer to the currently configured issuer.
 	 * @return the {@link VaultIssuerCertificateRequestResponse} containing a
 	 * {@link org.springframework.vault.support.Certificate}
 	 * @see <a href=
@@ -123,7 +122,7 @@ public interface VaultPkiOperations {
 	 * /pki/issuer/:issuer_ref/json</a>
 	 *
 	 */
-	VaultIssuerCertificateRequestResponse getIssuerCertificate(@Nullable String issuer) throws VaultException;
+	VaultIssuerCertificateRequestResponse getIssuerCertificate(String issuer) throws VaultException;
 
 	/**
 	 * Retrieves the specified issuer's certificate. Includes the full ca_chain of the
@@ -134,6 +133,6 @@ public interface VaultPkiOperations {
 	 * "https://www.vaultproject.io/api/secret/pki/#read-issuer-certificate">GET
 	 * /pki/issuer/:issuer_ref/{der, pem}</a>
 	 */
-	InputStream getIssuerCertificate(@Nullable String issuer, Encoding encoding) throws VaultException;
+	InputStream getIssuerCertificate(String issuer, Encoding encoding) throws VaultException;
 
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiOperations.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiOperations.java
@@ -22,6 +22,7 @@ import org.springframework.vault.VaultException;
 import org.springframework.vault.support.CertificateBundle;
 import org.springframework.vault.support.VaultCertificateRequest;
 import org.springframework.vault.support.VaultCertificateResponse;
+import org.springframework.vault.support.VaultIssuerCertificateRequestResponse;
 import org.springframework.vault.support.VaultSignCertificateRequestResponse;
 
 /**
@@ -107,5 +108,32 @@ public interface VaultPkiOperations {
 		DER, PEM,
 
 	}
+
+	/**
+	 * Retrieves the specified issuer's certificate. Includes the full ca_chain of the
+	 * issuer.
+	 * @param issuer reference to an existing issuer, either by Vault-generated
+	 * identifier, or the name assigned to an issuer. If empty or {@literal null}, the
+	 * issuer will default to the literal string default to refer to the currently
+	 * configured default issuer.
+	 * @return the {@link VaultIssuerCertificateRequestResponse} containing a
+	 * {@link org.springframework.vault.support.Certificate}
+	 * @see <a href=
+	 * "https://www.vaultproject.io/api/secret/pki/#read-issuer-certificate">GET *
+	 * /pki/issuer/:issuer_ref/json</a>
+	 *
+	 */
+	VaultIssuerCertificateRequestResponse getIssuerCertificate(@Nullable String issuer) throws VaultException;
+
+	/**
+	 * Retrieves the specified issuer's certificate. Includes the full ca_chain of the
+	 * issuer.
+	 * @return {@link java.io.InputStream} containing the encoded certificate or
+	 * {@literal null}
+	 * @see <a href=
+	 * "https://www.vaultproject.io/api/secret/pki/#read-issuer-certificate">GET
+	 * /pki/issuer/:issuer_ref/{der, pem}</a>
+	 */
+	InputStream getIssuerCertificate(@Nullable String issuer, Encoding encoding) throws VaultException;
 
 }

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -184,6 +183,8 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 			.to("exclude_cn_from_sans", request);
 		mapper.from(certificateRequest::getFormat).whenHasText().to("format", request);
 		mapper.from(certificateRequest::getPrivateKeyFormat).whenHasText().to("private_key_format", request);
+		mapper.from(certificateRequest::getNotAfter).whenHasText().as(i -> i.toString()).to("not_after", request);
+		mapper.from(certificateRequest::getUserIds).whenHasText().to("user_ids", request);
 
 		return request;
 	}

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultPkiTemplate.java
@@ -149,12 +149,13 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 	@Override
 	public VaultIssuerCertificateRequestResponse getIssuerCertificate(String issuer) throws VaultException {
 
+		Assert.hasText(issuer, "Issuer must not be empty");
+
 		return this.vaultOperations.doWithSession(restOperations -> {
 
 			try {
 				return restOperations.getForObject("{path}/issuer/{issuer}/json",
-						VaultIssuerCertificateRequestResponse.class, this.path,
-						StringUtils.hasText(issuer) ? issuer : "default");
+						VaultIssuerCertificateRequestResponse.class, this.path, issuer);
 			}
 			catch (HttpStatusCodeException e) {
 				throw VaultResponses.buildException(e);
@@ -164,6 +165,7 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 
 	@Override
 	public InputStream getIssuerCertificate(String issuer, Encoding encoding) throws VaultException {
+		Assert.hasText(issuer, "Issuer must not be empty");
 		Assert.notNull(encoding, "Encoding must not be null");
 
 		return this.vaultOperations.doWithSession(restOperations -> {
@@ -171,7 +173,7 @@ public class VaultPkiTemplate implements VaultPkiOperations {
 			String requestPath = encoding == Encoding.DER ? "{path}/issuer/{issuer}/der" : "{path}/issuer/{issuer}/pem";
 			try {
 				ResponseEntity<byte[]> response = restOperations.getForEntity(requestPath, byte[].class, this.path,
-						StringUtils.hasText(issuer) ? issuer : "default");
+						issuer);
 
 				if (response.getStatusCode().is2xxSuccessful() && response.hasBody()) {
 					return new ByteArrayInputStream(response.getBody());

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/Certificate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/Certificate.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.Base64Utils;
 import org.springframework.vault.VaultException;
@@ -49,11 +50,11 @@ public class Certificate {
 
 	private final List<String> caChain;
 
-	private final long revocationTime;
+	private final Long revocationTime;
 
 	Certificate(@JsonProperty("serial_number") String serialNumber, @JsonProperty("certificate") String certificate,
 			@JsonProperty("issuing_ca") String issuingCaCertificate, @JsonProperty("ca_chain") List<String> caChain,
-			@JsonProperty("revocation_time") long revocationTime) {
+			@JsonProperty("revocation_time") Long revocationTime) {
 
 		this.serialNumber = serialNumber;
 		this.certificate = certificate;
@@ -70,12 +71,53 @@ public class Certificate {
 	 * @param issuingCaCertificate must not be empty or {@literal null}.
 	 * @return the {@link Certificate}
 	 */
-	public static Certificate of(String serialNumber, String certificate, String issuingCaCertificate,
-			List<String> caChain, long revocationTime) {
+	public static Certificate of(String serialNumber, String certificate, String issuingCaCertificate) {
 
 		Assert.hasText(serialNumber, "Serial number must not be empty");
 		Assert.hasText(certificate, "Certificate must not be empty");
 		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
+
+		return new Certificate(serialNumber, certificate, issuingCaCertificate, List.of(), null);
+	}
+
+	/**
+	 * Create a {@link Certificate} given a private key with certificates and the serial
+	 * number.
+	 * @param serialNumber must not be empty or {@literal null}.
+	 * @param certificate must not be empty or {@literal null}.
+	 * @param issuingCaCertificate must not be empty or {@literal null}.
+	 * @param caChain empty list allowed
+	 * @return the {@link Certificate}
+	 */
+	public static Certificate of(String serialNumber, String certificate, String issuingCaCertificate,
+			List<String> caChain) {
+
+		Assert.hasText(serialNumber, "Serial number must not be empty");
+		Assert.hasText(certificate, "Certificate must not be empty");
+		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
+		Assert.notNull(caChain, "CA chain must not be null");
+
+		return new Certificate(serialNumber, certificate, issuingCaCertificate, caChain, null);
+	}
+
+	/**
+	 * Create a {@link Certificate} given a private key with certificates and the serial
+	 * number.
+	 * @param serialNumber must not be empty or {@literal null}.
+	 * @param certificate must not be empty or {@literal null}.
+	 * @param issuingCaCertificate must not be empty or {@literal null}.
+	 * @param caChain empty list allowed
+	 * @param revocationTime revocation time, must not be {@literal null}
+	 * @return the {@link Certificate}
+	 */
+	public static Certificate of(String serialNumber, String certificate, String issuingCaCertificate,
+			List<String> caChain, Long revocationTime) {
+
+		Assert.hasText(serialNumber, "Serial number must not be empty");
+		Assert.hasText(certificate, "Certificate must not be empty");
+		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
+		Assert.notNull(caChain, "CA chain must not be null");
+		Assert.notNull(revocationTime, "Revocation time");
 
 		return new Certificate(serialNumber, certificate, issuingCaCertificate, caChain, revocationTime);
 	}
@@ -208,7 +250,7 @@ public class Certificate {
 		return certificates;
 	}
 
-	public long getRevocationTime() {
+	public @Nullable Long getRevocationTime() {
 		return this.revocationTime;
 	}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
@@ -68,9 +68,9 @@ public class CertificateBundle extends Certificate {
 	 */
 	CertificateBundle(@JsonProperty("serial_number") String serialNumber,
 			@JsonProperty("certificate") String certificate, @JsonProperty("issuing_ca") String issuingCaCertificate,
-			@JsonProperty("ca_chain") List<String> caChain, @JsonProperty("revocation_time") long revocationTime,
-			@JsonProperty("private_key") String privateKey,
-			@Nullable @JsonProperty("private_key_type") String privateKeyType) {
+			@JsonProperty("ca_chain") List<String> caChain, @JsonProperty("private_key") String privateKey,
+			@Nullable @JsonProperty("private_key_type") String privateKeyType,
+			@JsonProperty("revocation_time") Long revocationTime) {
 
 		super(serialNumber, certificate, issuingCaCertificate, caChain, revocationTime);
 		this.privateKey = privateKey;
@@ -84,11 +84,10 @@ public class CertificateBundle extends Certificate {
 	 * @param certificate must not be empty or {@literal null}.
 	 * @param issuingCaCertificate must not be empty or {@literal null}.
 	 * @param privateKey must not be empty or {@literal null}.
-	 * @param revocationTime the revocation time.
 	 * @return the {@link CertificateBundle} instead.
 	 */
 	public static CertificateBundle of(String serialNumber, String certificate, String issuingCaCertificate,
-			String privateKey, long revocationTime) {
+			String privateKey) {
 
 		Assert.hasText(serialNumber, "Serial number must not be empty");
 		Assert.hasText(certificate, "Certificate must not be empty");
@@ -96,7 +95,31 @@ public class CertificateBundle extends Certificate {
 		Assert.hasText(privateKey, "Private key must not be empty");
 
 		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
-				Collections.singletonList(issuingCaCertificate), revocationTime, privateKey, null);
+				Collections.singletonList(issuingCaCertificate), null, privateKey, null);
+	}
+
+	/**
+	 * Create a {@link CertificateBundle} given a private key with certificates and the
+	 * serial number.
+	 * @param serialNumber must not be empty or {@literal null}.
+	 * @param certificate must not be empty or {@literal null}.
+	 * @param issuingCaCertificate must not be empty or {@literal null}.
+	 * @param privateKey must not be empty or {@literal null}.
+	 * @param privateKeyType must not be empty or {@literal null}.
+	 * @return the {@link CertificateBundle}
+	 * @since 2.4
+	 */
+	public static CertificateBundle of(String serialNumber, String certificate, String issuingCaCertificate,
+			String privateKey, @Nullable String privateKeyType) {
+
+		Assert.hasText(serialNumber, "Serial number must not be empty");
+		Assert.hasText(certificate, "Certificate must not be empty");
+		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
+		Assert.hasText(privateKey, "Private key must not be empty");
+		Assert.hasText(privateKeyType, "Private key type must not be empty");
+
+		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
+				Collections.singletonList(issuingCaCertificate), privateKey, privateKeyType, null);
 	}
 
 	/**
@@ -112,16 +135,17 @@ public class CertificateBundle extends Certificate {
 	 * @since 2.4
 	 */
 	public static CertificateBundle of(String serialNumber, String certificate, String issuingCaCertificate,
-			String privateKey, @Nullable String privateKeyType, long revocationTime) {
+			String privateKey, @Nullable String privateKeyType, Long revocationTime) {
 
 		Assert.hasText(serialNumber, "Serial number must not be empty");
 		Assert.hasText(certificate, "Certificate must not be empty");
 		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
 		Assert.hasText(privateKey, "Private key must not be empty");
 		Assert.hasText(privateKeyType, "Private key type must not be empty");
+		Assert.notNull(revocationTime, "Revocation time must not be null");
 
 		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
-				Collections.singletonList(issuingCaCertificate), revocationTime, privateKey, privateKeyType);
+				Collections.singletonList(issuingCaCertificate), privateKey, privateKeyType, revocationTime);
 	}
 
 	/**

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
@@ -18,7 +18,6 @@ package org.springframework.vault.support;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.KeySpec;
 import java.util.ArrayList;
@@ -58,8 +57,6 @@ public class CertificateBundle extends Certificate {
 	@Nullable
 	private final String privateKeyType;
 
-	private final List<String> caChain;
-
 	/**
 	 * Create a new {@link CertificateBundle}.
 	 * @param serialNumber the serial number.
@@ -71,13 +68,13 @@ public class CertificateBundle extends Certificate {
 	 */
 	CertificateBundle(@JsonProperty("serial_number") String serialNumber,
 			@JsonProperty("certificate") String certificate, @JsonProperty("issuing_ca") String issuingCaCertificate,
-			@JsonProperty("ca_chain") List<String> caChain, @JsonProperty("private_key") String privateKey,
+			@JsonProperty("ca_chain") List<String> caChain, @JsonProperty("revocation_time") long revocationTime,
+			@JsonProperty("private_key") String privateKey,
 			@Nullable @JsonProperty("private_key_type") String privateKeyType) {
 
-		super(serialNumber, certificate, issuingCaCertificate);
+		super(serialNumber, certificate, issuingCaCertificate, caChain, revocationTime);
 		this.privateKey = privateKey;
 		this.privateKeyType = privateKeyType;
-		this.caChain = caChain;
 	}
 
 	/**
@@ -87,10 +84,11 @@ public class CertificateBundle extends Certificate {
 	 * @param certificate must not be empty or {@literal null}.
 	 * @param issuingCaCertificate must not be empty or {@literal null}.
 	 * @param privateKey must not be empty or {@literal null}.
+	 * @param revocationTime the revocation time.
 	 * @return the {@link CertificateBundle} instead.
 	 */
 	public static CertificateBundle of(String serialNumber, String certificate, String issuingCaCertificate,
-			String privateKey) {
+			String privateKey, long revocationTime) {
 
 		Assert.hasText(serialNumber, "Serial number must not be empty");
 		Assert.hasText(certificate, "Certificate must not be empty");
@@ -98,7 +96,7 @@ public class CertificateBundle extends Certificate {
 		Assert.hasText(privateKey, "Private key must not be empty");
 
 		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
-				Collections.singletonList(issuingCaCertificate), privateKey, null);
+				Collections.singletonList(issuingCaCertificate), revocationTime, privateKey, null);
 	}
 
 	/**
@@ -109,11 +107,12 @@ public class CertificateBundle extends Certificate {
 	 * @param issuingCaCertificate must not be empty or {@literal null}.
 	 * @param privateKey must not be empty or {@literal null}.
 	 * @param privateKeyType must not be empty or {@literal null}.
+	 * @param revocationTime the revocation time.
 	 * @return the {@link CertificateBundle}
 	 * @since 2.4
 	 */
 	public static CertificateBundle of(String serialNumber, String certificate, String issuingCaCertificate,
-			String privateKey, @Nullable String privateKeyType) {
+			String privateKey, @Nullable String privateKeyType, long revocationTime) {
 
 		Assert.hasText(serialNumber, "Serial number must not be empty");
 		Assert.hasText(certificate, "Certificate must not be empty");
@@ -122,7 +121,7 @@ public class CertificateBundle extends Certificate {
 		Assert.hasText(privateKeyType, "Private key type must not be empty");
 
 		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
-				Collections.singletonList(issuingCaCertificate), privateKey, privateKeyType);
+				Collections.singletonList(issuingCaCertificate), revocationTime, privateKey, privateKeyType);
 	}
 
 	/**
@@ -274,27 +273,6 @@ public class CertificateBundle extends Certificate {
 		catch (GeneralSecurityException | IOException e) {
 			throw new VaultException("Cannot create KeyStore", e);
 		}
-	}
-
-	/**
-	 * Retrieve the issuing CA certificates as list of {@link X509Certificate}.
-	 * @return the issuing CA {@link X509Certificate}.
-	 * @since 2.3.3
-	 */
-	public List<X509Certificate> getX509IssuerCertificates() {
-
-		List<X509Certificate> certificates = new ArrayList<>();
-
-		for (String data : this.caChain) {
-			try {
-				certificates.addAll(getCertificates(data));
-			}
-			catch (CertificateException e) {
-				throw new VaultException("Cannot create Certificate from issuing CA certificate", e);
-			}
-		}
-
-		return certificates;
 	}
 
 	private static KeySpec getPrivateKey(String privateKey, String keyType)

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultIssuerCertificateRequestResponse.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultIssuerCertificateRequestResponse.java
@@ -18,7 +18,7 @@ package org.springframework.vault.support;
 /**
  * Value object to bind Vault HTTP PKI issue certificate API responses.
  *
- * @author Mark Paluch
+ * @author Nanne Baars
  */
 public class VaultIssuerCertificateRequestResponse extends VaultResponseSupport<Certificate> {
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/VaultIssuerCertificateRequestResponse.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/VaultIssuerCertificateRequestResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.vault.support;
+
+/**
+ * Value object to bind Vault HTTP PKI issue certificate API responses.
+ *
+ * @author Mark Paluch
+ */
+public class VaultIssuerCertificateRequestResponse extends VaultResponseSupport<Certificate> {
+
+}

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
@@ -450,7 +450,7 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 
 	@Test
 	void shouldReturnCA() throws Exception {
-		VaultIssuerCertificateRequestResponse certificateResponse = this.pkiOperations.getIssuerCertificate(null);
+		VaultIssuerCertificateRequestResponse certificateResponse = this.pkiOperations.getIssuerCertificate("default");
 
 		Certificate data = certificateResponse.getRequiredData();
 		KeyStore trustStore = data.createTrustStore(true);
@@ -458,14 +458,14 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 		assertThat(data.getCertificate()).isNotEmpty();
 		assertThat(data.getX509IssuerCertificates()).hasSize(2);
 
-		try (InputStream in = this.pkiOperations.getIssuerCertificate(null, Encoding.DER)) {
+		try (InputStream in = this.pkiOperations.getIssuerCertificate("default", Encoding.DER)) {
 
 			CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
 			assertThat(cf.generateCertificate(in)).isInstanceOf(java.security.cert.Certificate.class);
 		}
 
-		try (InputStream crl = this.pkiOperations.getIssuerCertificate(null, Encoding.PEM)) {
+		try (InputStream crl = this.pkiOperations.getIssuerCertificate("default", Encoding.PEM)) {
 
 			byte[] bytes = StreamUtils.copyToByteArray(crl);
 			assertThat(bytes).isNotEmpty();

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
@@ -52,6 +52,7 @@ import org.springframework.vault.support.Certificate;
 import org.springframework.vault.support.CertificateBundle;
 import org.springframework.vault.support.VaultCertificateRequest;
 import org.springframework.vault.support.VaultCertificateResponse;
+import org.springframework.vault.support.VaultIssuerCertificateRequestResponse;
 import org.springframework.vault.support.VaultSignCertificateRequestResponse;
 import org.springframework.vault.util.IntegrationTestSupport;
 import org.springframework.vault.util.RequiresVaultVersion;
@@ -445,6 +446,31 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 			byte[] bytes = StreamUtils.copyToByteArray(crl);
 			assertThat(bytes).isNotEmpty();
 		}
+	}
+
+	@Test
+	void shouldReturnCA() throws Exception {
+		VaultIssuerCertificateRequestResponse certificateResponse = this.pkiOperations.getIssuerCertificate(null);
+
+		Certificate data = certificateResponse.getRequiredData();
+		KeyStore trustStore = data.createTrustStore(true);
+		assertThat(trustStore.size()).isEqualTo(3);
+		assertThat(data.getCertificate()).isNotEmpty();
+		assertThat(data.getX509IssuerCertificates()).hasSize(2);
+
+		try (InputStream in = this.pkiOperations.getIssuerCertificate(null, Encoding.DER)) {
+
+			CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+			assertThat(cf.generateCertificate(in)).isInstanceOf(java.security.cert.Certificate.class);
+		}
+
+		try (InputStream crl = this.pkiOperations.getIssuerCertificate(null, Encoding.PEM)) {
+
+			byte[] bytes = StreamUtils.copyToByteArray(crl);
+			assertThat(bytes).isNotEmpty();
+		}
+
 	}
 
 }

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultPkiTemplateIntegrationTests.java
@@ -56,6 +56,7 @@ import org.springframework.vault.support.VaultSignCertificateRequestResponse;
 import org.springframework.vault.util.IntegrationTestSupport;
 import org.springframework.vault.util.RequiresVaultVersion;
 import org.springframework.vault.util.Version;
+import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.vault.util.Settings.*;
@@ -114,6 +115,7 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 		role.put("allowed_domains", "localhost,example.com");
 		role.put("allow_subdomains", "true");
 		role.put("allow_localhost", "true");
+		role.put("allowed_user_ids", "humanoid,robot");
 		role.put("allow_ip_sans", "true");
 		role.put("max_ttl", "72h");
 
@@ -124,7 +126,6 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 			role.put("key_bits", "" + value.bits);
 			this.vaultOperations.write("pki/roles/testrole-" + value.name(), role);
 		}
-
 	}
 
 	@Test
@@ -262,6 +263,106 @@ class VaultPkiTemplateIntegrationTests extends IntegrationTestSupport {
 		Instant now = Instant.now();
 		assertThat(certificate.getNotAfter()).isAfter(Date.from(now.plus(40, ChronoUnit.HOURS)))
 			.isBefore(Date.from(now.plus(50, ChronoUnit.HOURS)));
+	}
+
+	@Test
+	void signShouldSignCsrWithNotAfter() {
+		Instant notAfter = Instant.now().plus(50, ChronoUnit.DAYS);
+		String csr = "-----BEGIN CERTIFICATE REQUEST-----\n"
+				+ "MIICzTCCAbUCAQAwgYcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRl\n"
+				+ "MRUwEwYDVQQHEwxTYW4gVmF1bHRpbm8xFTATBgNVBAoTDFNwcmluZyBWYXVsdDEY\n"
+				+ "MBYGA1UEAxMPY3NyLmV4YW1wbGUuY29tMRswGQYJKoZIhvcNAQkBFgxzcHJpbmdA\n"
+				+ "dmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVlDBT1gAONIp4\n"
+				+ "GQQ7BWDeqNzlscWqu5oQyfvw6oNFZzYWGVTgX/n72biv8d1Wx30MWpVYhbL0mk9m\n"
+				+ "Uu15elMZHPb4F4bk8VDSiB9527SwAd/QpkNC1RsPp2h6g2LvGPJ2eidHSlLtF2To\n"
+				+ "A4i6z0K0++nvYKSf9Af0sod2Z51xc9uPj/oN5z/8BQuGoCBpxJqgl7N/csMICixY\n"
+				+ "2fQcCUbdPPqE9INIInUHe3mPE/yvxko9aYGZ5jnrdZyiQaRRKBdWpvbRLKXQ78Fz\n"
+				+ "vXR3G33yn9JAN6wl1A916DiXzy2xHT19vyAn1hBUj2M6KFXChQ30oxTyTOqHCMLP\n"
+				+ "m/BSEOsPAgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAYFssueiUh3YGxnXcQ4dp\n"
+				+ "ZqVWeVyOuGGaFJ4BA0drwJ9Mt/iNmPUTGE2oBNnh2R7e7HwGcNysFHZZOZBEQ0Hh\n"
+				+ "Vn93GO7cfaTOetK0VtDqis1VFQD0eVPWf5s6UqT/+XGrFRhwJ9hM+2FQSrUDFecs\n"
+				+ "+/605n1rD7qOj3vkGrtwvEUrxyRaQaKpPLHmVHENqV6F1NsO3Z27f2FWWAZF2VKN\n"
+				+ "cCQQJNc//DbIN3J3JSElpIDBDHctoBoQVnMiwpCbSA+CaAtlWYJKnAfhTKeqnNMy\n"
+				+ "qf3ACZ+1sBIuqSP7dEJ2KfIezaCPQ88+PAloRB52LFa+iq3yI7F5VzkwAvQFnTi+\n" + "cQ==\n"
+				+ "-----END CERTIFICATE REQUEST-----";
+
+		VaultCertificateRequest request = VaultCertificateRequest.builder()
+			.commonName("hello.example.com")
+			.notAfter(notAfter)
+			.build();
+
+		VaultSignCertificateRequestResponse certificateResponse = this.pkiOperations.signCertificateRequest("testrole",
+				csr, request);
+
+		Certificate data = certificateResponse.getRequiredData();
+		assertThat(data.getX509Certificate().getNotAfter()).isEqualTo(notAfter.truncatedTo(ChronoUnit.SECONDS));
+	}
+
+	@Test
+	@RequiresVaultVersion("1.14.2")
+	void signShouldFailWithUnknownUserIds() {
+		String csr = "-----BEGIN CERTIFICATE REQUEST-----\n"
+				+ "MIICzTCCAbUCAQAwgYcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRl\n"
+				+ "MRUwEwYDVQQHEwxTYW4gVmF1bHRpbm8xFTATBgNVBAoTDFNwcmluZyBWYXVsdDEY\n"
+				+ "MBYGA1UEAxMPY3NyLmV4YW1wbGUuY29tMRswGQYJKoZIhvcNAQkBFgxzcHJpbmdA\n"
+				+ "dmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVlDBT1gAONIp4\n"
+				+ "GQQ7BWDeqNzlscWqu5oQyfvw6oNFZzYWGVTgX/n72biv8d1Wx30MWpVYhbL0mk9m\n"
+				+ "Uu15elMZHPb4F4bk8VDSiB9527SwAd/QpkNC1RsPp2h6g2LvGPJ2eidHSlLtF2To\n"
+				+ "A4i6z0K0++nvYKSf9Af0sod2Z51xc9uPj/oN5z/8BQuGoCBpxJqgl7N/csMICixY\n"
+				+ "2fQcCUbdPPqE9INIInUHe3mPE/yvxko9aYGZ5jnrdZyiQaRRKBdWpvbRLKXQ78Fz\n"
+				+ "vXR3G33yn9JAN6wl1A916DiXzy2xHT19vyAn1hBUj2M6KFXChQ30oxTyTOqHCMLP\n"
+				+ "m/BSEOsPAgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAYFssueiUh3YGxnXcQ4dp\n"
+				+ "ZqVWeVyOuGGaFJ4BA0drwJ9Mt/iNmPUTGE2oBNnh2R7e7HwGcNysFHZZOZBEQ0Hh\n"
+				+ "Vn93GO7cfaTOetK0VtDqis1VFQD0eVPWf5s6UqT/+XGrFRhwJ9hM+2FQSrUDFecs\n"
+				+ "+/605n1rD7qOj3vkGrtwvEUrxyRaQaKpPLHmVHENqV6F1NsO3Z27f2FWWAZF2VKN\n"
+				+ "cCQQJNc//DbIN3J3JSElpIDBDHctoBoQVnMiwpCbSA+CaAtlWYJKnAfhTKeqnNMy\n"
+				+ "qf3ACZ+1sBIuqSP7dEJ2KfIezaCPQ88+PAloRB52LFa+iq3yI7F5VzkwAvQFnTi+\n" + "cQ==\n"
+				+ "-----END CERTIFICATE REQUEST-----";
+
+		VaultCertificateRequest request = VaultCertificateRequest.builder()
+			.commonName("hello.example.com")
+			.userIds("test1,test2")
+			.build();
+
+		assertThatThrownBy(() -> this.pkiOperations.signCertificateRequest("testrole", csr, request))
+			.hasCauseInstanceOf(HttpClientErrorException.BadRequest.class)
+			.hasMessageContaining("user_id test1 is not allowed by this role");
+	}
+
+	@Test
+	@RequiresVaultVersion("1.14.2")
+	void signShouldSignWithKnownUserIds() {
+		String csr = "-----BEGIN CERTIFICATE REQUEST-----\n"
+				+ "MIICzTCCAbUCAQAwgYcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRl\n"
+				+ "MRUwEwYDVQQHEwxTYW4gVmF1bHRpbm8xFTATBgNVBAoTDFNwcmluZyBWYXVsdDEY\n"
+				+ "MBYGA1UEAxMPY3NyLmV4YW1wbGUuY29tMRswGQYJKoZIhvcNAQkBFgxzcHJpbmdA\n"
+				+ "dmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVlDBT1gAONIp4\n"
+				+ "GQQ7BWDeqNzlscWqu5oQyfvw6oNFZzYWGVTgX/n72biv8d1Wx30MWpVYhbL0mk9m\n"
+				+ "Uu15elMZHPb4F4bk8VDSiB9527SwAd/QpkNC1RsPp2h6g2LvGPJ2eidHSlLtF2To\n"
+				+ "A4i6z0K0++nvYKSf9Af0sod2Z51xc9uPj/oN5z/8BQuGoCBpxJqgl7N/csMICixY\n"
+				+ "2fQcCUbdPPqE9INIInUHe3mPE/yvxko9aYGZ5jnrdZyiQaRRKBdWpvbRLKXQ78Fz\n"
+				+ "vXR3G33yn9JAN6wl1A916DiXzy2xHT19vyAn1hBUj2M6KFXChQ30oxTyTOqHCMLP\n"
+				+ "m/BSEOsPAgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAYFssueiUh3YGxnXcQ4dp\n"
+				+ "ZqVWeVyOuGGaFJ4BA0drwJ9Mt/iNmPUTGE2oBNnh2R7e7HwGcNysFHZZOZBEQ0Hh\n"
+				+ "Vn93GO7cfaTOetK0VtDqis1VFQD0eVPWf5s6UqT/+XGrFRhwJ9hM+2FQSrUDFecs\n"
+				+ "+/605n1rD7qOj3vkGrtwvEUrxyRaQaKpPLHmVHENqV6F1NsO3Z27f2FWWAZF2VKN\n"
+				+ "cCQQJNc//DbIN3J3JSElpIDBDHctoBoQVnMiwpCbSA+CaAtlWYJKnAfhTKeqnNMy\n"
+				+ "qf3ACZ+1sBIuqSP7dEJ2KfIezaCPQ88+PAloRB52LFa+iq3yI7F5VzkwAvQFnTi+\n" + "cQ==\n"
+				+ "-----END CERTIFICATE REQUEST-----";
+
+		VaultCertificateRequest request = VaultCertificateRequest.builder()
+			.commonName("hello.example.com")
+			.userIds("robot,humanoid")
+			.build();
+
+		VaultSignCertificateRequestResponse certificateResponse = this.pkiOperations.signCertificateRequest("testrole",
+				csr, request);
+
+		Certificate data = certificateResponse.getRequiredData();
+
+		assertThat(data.getCertificate()).isNotEmpty();
+		assertThat(data.getX509Certificate().getSubjectX500Principal().getName()).contains("UID=humanoid")
+			.contains("UID=robot");
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/support/CertificateUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/support/CertificateUnitTests.java
@@ -17,6 +17,7 @@ package org.springframework.vault.support;
 
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +42,8 @@ class CertificateUnitTests {
 	void before() throws Exception {
 		Map<String, String> data = this.OBJECT_MAPPER.readValue(getClass().getResource("/certificate.json"), Map.class);
 
-		this.certificate = Certificate.of(data.get("serial_number"), data.get("certificate"), data.get("issuing_ca"));
+		this.certificate = Certificate.of(data.get("serial_number"), data.get("certificate"), data.get("issuing_ca"),
+				List.of(), 0L);
 	}
 
 	@Test


### PR DESCRIPTION
Add some extra fields through the request. The `userIds` one depends on a later Vault [version](https://github.com/hashicorp/vault/releases/tag/v1.14.2), those are behind `RequiresVaultVersion`. 

Related to: gh-477