### PR TITLE
fix-comparison

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/env/LeaseAwareVaultPropertySource.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/env/LeaseAwareVaultPropertySource.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.vault.core.env;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
@@ -221,7 +218,7 @@ public class LeaseAwareVaultPropertySource extends EnumerablePropertySource<Vaul
 	 */
 	protected void handleLeaseEvent(SecretLeaseEvent leaseEvent, Map<String, Object> properties) {
 
-		if (leaseEvent.getSource() != getRequestedSecret()) {
+		if (!Objects.equals(leaseEvent.getSource(), getRequestedSecret())) {
 			return;
 		}
 
@@ -259,7 +256,7 @@ public class LeaseAwareVaultPropertySource extends EnumerablePropertySource<Vaul
 	 */
 	protected void handleLeaseErrorEvent(SecretLeaseEvent leaseEvent, Exception exception) {
 
-		if (leaseEvent.getSource() != getRequestedSecret()) {
+		if (!Objects.equals(leaseEvent.getSource(), getRequestedSecret())) {
 			return;
 		}
 

--- a/spring-vault-core/src/main/java/org/springframework/vault/core/env/LeaseAwareVaultPropertySource.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/env/LeaseAwareVaultPropertySource.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.vault.core.env;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
Hello,

I'm using Spring Cloud AWS in prod to retrieve ROTATE credentials for connecting to the OpenSearch service, but it's not working as expected. I can see, that Spring Cloud loads new credentials every hour, but the environment variables don't seem to be updating. To achieve the desired behavior, I had to make a small, specific change. For me it seems like a small bag fix.