### PR TITLE
Adding leading slash to prevent URI is not absolute errors

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationUtil.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/AuthenticationUtil.java
@@ -13,7 +13,7 @@ abstract class AuthenticationUtil {
 	 * @return
 	 */
 	static String getLoginPath(String authMount) {
-		return "auth/%s/login".formatted(authMount);
+		return "/auth/%s/login".formatted(authMount);
 	}
 
 	private AuthenticationUtil() {


### PR DESCRIPTION
The lack of a leading slash here results in a java.lang.IllegalArgumentException: URI is not absolute error when using AwsIamAuthentication createTokenUsingAwsIam method