### PR TITLE
Use default constructor for JacksonHttpMessageConverters

### DIFF
--- a/spring-vault-core/pom.xml
+++ b/spring-vault-core/pom.xml
@@ -276,6 +276,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>tools.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
+			<version>${jackson-databind.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>

--- a/spring-vault-core/src/main/java/org/springframework/vault/support/JacksonCompat.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/JacksonCompat.java
@@ -168,15 +168,13 @@ public abstract class JacksonCompat {
 
 		static final Jackson2 INSTANCE = new Jackson2();
 
-		static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
 		static final ObjectMapper PRETTY_PRINT_OBJECT_MAPPER = new ObjectMapper()
 				.enable(SerializationFeature.INDENT_OUTPUT);
 
-		static final Jackson2ObjectMapperAccessor MAPPER_ACCESSOR = new Jackson2ObjectMapperAccessor(OBJECT_MAPPER);
+		static final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
 
-		static final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(
-				OBJECT_MAPPER);
+		static final Jackson2ObjectMapperAccessor MAPPER_ACCESSOR = new Jackson2ObjectMapperAccessor(
+				converter.getObjectMapper());
 
 
 		public static boolean isAvailable() {
@@ -192,8 +190,8 @@ public abstract class JacksonCompat {
 		@Override
 		public void registerCodecs(Consumer<Object> messageConverters) {
 
-			messageConverters.accept(new Jackson2JsonDecoder(OBJECT_MAPPER));
-			messageConverters.accept(new Jackson2JsonEncoder(OBJECT_MAPPER));
+			messageConverters.accept(new Jackson2JsonDecoder(converter.getObjectMapper()));
+			messageConverters.accept(new Jackson2JsonEncoder(converter.getObjectMapper()));
 		}
 
 		@Override
@@ -275,17 +273,15 @@ public abstract class JacksonCompat {
 
 		static final Jackson3 INSTANCE = new Jackson3();
 
-		static final tools.jackson.databind.json.JsonMapper JSON_MAPPER = JsonMapper.builder().build();
-
 		static final tools.jackson.databind.ObjectMapper PRETTY_PRINT_OBJECT_MAPPER = JsonMapper.builder()
 				.enable(tools.jackson.databind.SerializationFeature.INDENT_OUTPUT)
 				.disable(JsonWriteFeature.ESCAPE_FORWARD_SLASHES)
 				.build();
 
-		static final Jackson3ObjectMapperAccessor MAPPER_ACCESSOR = new Jackson3ObjectMapperAccessor(
+		static final Jackson3ObjectMapperAccessor PRETTY_PRINT_MAPPER_ACCESSOR = new Jackson3ObjectMapperAccessor(
 				PRETTY_PRINT_OBJECT_MAPPER);
 
-		static final JacksonJsonHttpMessageConverter converter = new JacksonJsonHttpMessageConverter(JSON_MAPPER);
+		static final JacksonJsonHttpMessageConverter converter = new JacksonJsonHttpMessageConverter();
 
 
 		public static boolean isAvailable() {
@@ -301,8 +297,8 @@ public abstract class JacksonCompat {
 		@Override
 		public void registerCodecs(Consumer<Object> messageConverters) {
 
-			messageConverters.accept(new JacksonJsonDecoder(JSON_MAPPER));
-			messageConverters.accept(new JacksonJsonEncoder(JSON_MAPPER));
+			messageConverters.accept(new JacksonJsonDecoder(converter.getMapper()));
+			messageConverters.accept(new JacksonJsonEncoder(converter.getMapper()));
 		}
 
 		@Override
@@ -317,12 +313,12 @@ public abstract class JacksonCompat {
 
 		@Override
 		public ObjectMapperAccessor getObjectMapperAccessor() {
-			return new Jackson3.Jackson3ObjectMapperAccessor(JSON_MAPPER);
+			return new Jackson3.Jackson3ObjectMapperAccessor(converter.getMapper());
 		}
 
 		@Override
 		public ObjectMapperAccessor getPrettyPrintObjectMapperAccessor() {
-			return MAPPER_ACCESSOR;
+			return PRETTY_PRINT_MAPPER_ACCESSOR;
 		}
 
 		public @Nullable ObjectMapperAccessor getObjectMapperAccessor(List<HttpMessageConverter<?>> converters) {

--- a/spring-vault-core/src/test/kotlin/org/springframework/vault/core/VaultTemplateKotlinJsonDecodingTests.kt
+++ b/spring-vault-core/src/test/kotlin/org/springframework/vault/core/VaultTemplateKotlinJsonDecodingTests.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.vault.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.vault.util.MockVaultClient
+
+/**
+ * Unit tests to validate [VaultTemplate] can decode into a Kotlin class.
+ *
+ * @author Braden Rayhorn
+ */
+class VaultTemplateKotlinJsonDecodingTests {
+
+    @Test
+    fun `VaultTemplate read extension should decode JSON into Kotlin class`() {
+        val mockVaultClient = MockVaultClient.create()
+
+        mockVaultClient.expect(requestTo(containsString("secret/mykey")))
+            .andExpect(method(HttpMethod.GET))
+            .andRespond(withSuccess("""{"data":{"secretString":"abc"}}""", MediaType.APPLICATION_JSON))
+
+        val response = VaultTemplate(mockVaultClient).read<SecretData>("secret/mykey")
+
+        assertThat(response?.data?.secretString).isEqualTo("abc")
+    }
+
+    class SecretData(val secretString: String)
+}


### PR DESCRIPTION
The default constructor will load known Jackson modules, including jackson-module-kotlin.
Currently, the known Jackson modules are not loaded. This seems to be a regression in spring-vault v4.

The module loading is needed to support things such as decoding to a Kotlin class.

Closes gh-976