### PR TITLE
Support VAULT_ADDR in EnvironmentVaultConfiguration

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/config/EnvironmentVaultConfiguration.java
@@ -81,7 +81,7 @@ import org.springframework.web.client.RestOperations;
  * Authentication-specific properties must be provided depending on the
  * authentication method.
  * <ul>
- * <li>Vault URI: {@code vault.uri}</li>
+ * <li>Vault URI: {@code vault.uri} (falls back to {@code VAULT_ADDR})</li>
  * <li>SSL Configuration
  * <ul>
  * <li>Keystore resource: {@code vault.ssl.key-store} (optional)</li>
@@ -223,10 +223,13 @@ public class EnvironmentVaultConfiguration extends AbstractVaultConfiguration im
 	@Override
 	public VaultEndpoint vaultEndpoint() {
 		String uri = getProperty("vault.uri");
+		if (uri == null) {
+			uri = getProperty("VAULT_ADDR");
+		}
 		if (uri != null) {
 			return VaultEndpoint.from(URI.create(uri));
 		}
-		throw new IllegalStateException("Vault URI (vault.uri) is null");
+		throw new IllegalStateException("Vault URI (vault.uri or VAULT_ADDR) is null");
 	}
 
 	@Override

--- a/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -63,6 +64,37 @@ class EnvironmentVaultConfigurationUnitTests {
 	@Test
 	void shouldConfigureEndpoint() {
 		assertThat(this.configuration.vaultEndpoint().getPort()).isEqualTo(8123);
+	}
+
+	@Test
+	void shouldConfigureEndpointUsingVaultAddr() {
+
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+
+			context.getEnvironment()
+					.getPropertySources()
+					.addFirst(new MapPropertySource("vaultAddr",
+							Map.of("VAULT_ADDR", "https://localhost:9123", "vault.token", "my-token")));
+			context.register(ApplicationConfiguration.class);
+			context.refresh();
+
+			assertThat(context.getBean(EnvironmentVaultConfiguration.class).vaultEndpoint().getPort()).isEqualTo(9123);
+		}
+	}
+
+	@Test
+	void shouldPreferVaultUriOverVaultAddr() {
+
+		MapPropertySource propertySource = new MapPropertySource("vaultAddr",
+				Map.of("VAULT_ADDR", "https://localhost:9123"));
+		this.configurableEnvironment.getPropertySources().addFirst(propertySource);
+
+		try {
+			assertThat(this.configuration.vaultEndpoint().getPort()).isEqualTo(8123);
+		}
+		finally {
+			this.configurableEnvironment.getPropertySources().remove(propertySource.getName());
+		}
 	}
 
 	@Test

--- a/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/config/EnvironmentVaultConfigurationUnitTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -63,6 +64,22 @@ class EnvironmentVaultConfigurationUnitTests {
 	@Test
 	void shouldConfigureEndpoint() {
 		assertThat(this.configuration.vaultEndpoint().getPort()).isEqualTo(8123);
+	}
+
+	@Test
+	void shouldConfigureEndpointUsingVaultAddr() {
+
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+
+			context.getEnvironment()
+					.getPropertySources()
+					.addFirst(new MapPropertySource("vaultAddr",
+							Map.of("VAULT_ADDR", "https://localhost:9123", "vault.token", "my-token")));
+			context.register(ApplicationConfiguration.class);
+			context.refresh();
+
+			assertThat(context.getBean(EnvironmentVaultConfiguration.class).vaultEndpoint().getPort()).isEqualTo(9123);
+		}
 	}
 
 	@Test

--- a/src/main/antora/modules/ROOT/pages/vault/imperative-template.adoc
+++ b/src/main/antora/modules/ROOT/pages/vault/imperative-template.adoc
@@ -177,7 +177,7 @@ vault.token=00000000-0000-0000-0000-000000000000
 
 **Property keys**
 
-* Vault URI: `vault.uri`
+* Vault URI: `vault.uri` (falls back to `VAULT_ADDR`)
 * SSL Configuration
 ** Keystore resource: `vault.ssl.key-store` (optional)
 ** Keystore password: `vault.ssl.key-store-password` (optional)

--- a/src/main/antora/modules/ROOT/pages/vault/imperative-template.adoc
+++ b/src/main/antora/modules/ROOT/pages/vault/imperative-template.adoc
@@ -176,7 +176,7 @@ vault.token=00000000-0000-0000-0000-000000000000
 
 **Property keys**
 
-* Vault URI: `vault.uri`
+* Vault URI: `vault.uri` (falls back to `VAULT_ADDR`)
 * SSL Configuration
 ** Keystore resource: `vault.ssl.key-store` (optional)
 ** Keystore password: `vault.ssl.key-store-password` (optional)


### PR DESCRIPTION
Closes #592

Adds `VAULT_ADDR` as a fallback when `vault.uri` is absent. The existing Spring Vault property remains preferred, and no generic environment-variable translation is introduced.

The reference documentation is updated with the fallback.

## Verification
- Regression test fails without the fallback
- `./mvnw -pl spring-vault-core -Dtest=EnvironmentVaultConfigurationUnitTests test` (4 tests)
- `./mvnw -pl spring-vault-core test` (498 tests, 0 failures/errors)
- `git diff --check`
