### PR TITLE
Retry reactive Vault login after failures

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManager.java
@@ -308,23 +308,33 @@ public class ReactiveLifecycleAwareSessionManager extends LifecycleAwareSessionM
 	public Mono<VaultToken> getVaultToken() throws VaultException {
 		Mono<TokenWrapper> tokenWrapper = this.token.get();
 		if (tokenWrapper == EMPTY) {
-			Mono<TokenWrapper> obtainToken = this.clientAuthentication.getVaultToken()
-					.flatMap(this::doSelfLookup) //
-					.onErrorMap(it -> {
-						multicastEvent(new LoginFailedEvent(this.clientAuthentication, it));
-						return it;
-					})
-					.doOnNext(it -> {
-						if (isTokenRenewable(it.getToken())) {
-							scheduleRenewal(it.getToken());
-						}
-						multicastEvent(new AfterLoginEvent(it.getToken()));
-					});
-
-			this.token.compareAndSet(tokenWrapper, obtainToken.cache());
+			Mono<TokenWrapper> obtainToken = createLoginTokenMono();
+			this.token.compareAndSet(tokenWrapper, obtainToken);
 		}
 
 		return this.token.get().map(TokenWrapper::getToken);
+	}
+
+	private Mono<TokenWrapper> createLoginTokenMono() {
+		AtomicReference<Mono<TokenWrapper>> cachedLoginRef = new AtomicReference<>(EMPTY);
+		Mono<TokenWrapper> obtainToken = this.clientAuthentication.getVaultToken()
+				.flatMap(this::doSelfLookup) //
+				.onErrorMap(it -> {
+					multicastEvent(new LoginFailedEvent(this.clientAuthentication, it));
+					return it;
+				})
+				.doOnNext(it -> {
+					if (isTokenRenewable(it.getToken())) {
+						scheduleRenewal(it.getToken());
+					}
+					multicastEvent(new AfterLoginEvent(it.getToken()));
+				})
+				.doOnError(it -> this.token.compareAndSet(cachedLoginRef.get(), EMPTY))
+				.cache();
+
+		cachedLoginRef.set(obtainToken);
+
+		return obtainToken;
 	}
 
 	private Mono<TokenWrapper> doSelfLookup(VaultToken token) {

--- a/spring-vault-core/src/test/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManagerUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/authentication/ReactiveLifecycleAwareSessionManagerUnitTests.java
@@ -148,6 +148,26 @@ class ReactiveLifecycleAwareSessionManagerUnitTests {
 	}
 
 	@Test
+	void shouldRetryLoginAfterFailure() {
+
+		when(this.tokenSupplier.getVaultToken()).thenReturn(Mono.error(new VaultLoginException("foo")),
+				Mono.just(LoginToken.of("login")));
+
+		this.sessionManager.getSessionToken() //
+				.as(StepVerifier::create) //
+				.verifyError(VaultLoginException.class);
+
+		this.sessionManager.getSessionToken() //
+				.as(StepVerifier::create) //
+				.expectNext(LoginToken.of("login")) //
+				.verifyComplete();
+
+		verify(this.tokenSupplier, times(2)).getVaultToken();
+		verify(this.errorListener).onAuthenticationError(any(LoginFailedEvent.class));
+		verify(this.listener).onAuthenticationEvent(any(AfterLoginEvent.class));
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void shouldSelfLookupToken() {
 


### PR DESCRIPTION
## Summary

- Reset the cached reactive login attempt when authentication fails, so later token requests can retry instead of replaying the same cached error.
- Keep successful login caching in place so concurrent callers still share a single token lookup.
- Add a regression test that fails the first login attempt and verifies the next call retries and succeeds.

## Issue

Addresses spring-cloud/spring-cloud-vault#940.

## Testing

- `./mvnw -pl spring-vault-core -Dtest=ReactiveLifecycleAwareSessionManagerUnitTests#shouldRetryLoginAfterFailure test`
- `./mvnw -pl spring-vault-core -Dtest=ReactiveLifecycleAwareSessionManagerUnitTests test`
- `src/test/bash/create_certificates.sh`
- `env -u SPRING_PROFILES_ACTIVE ./mvnw -pl spring-vault-core test`