### PR TITLE
GH-1018: Allow null secret values in SecretLeaseCreatedEvent

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/lease/event/SecretLeaseCreatedEvent.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/lease/event/SecretLeaseCreatedEvent.java
@@ -17,6 +17,8 @@
 package org.springframework.vault.core.lease.event;
 
 import java.io.Serial;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.vault.core.lease.domain.Lease;
@@ -27,6 +29,7 @@ import org.springframework.vault.core.lease.domain.RequestedSecret;
  * {@link Lease}.
  *
  * @author Mark Paluch
+ * @author Burak KALAYCI
  */
 public class SecretLeaseCreatedEvent extends SecretLeaseEvent {
 
@@ -42,11 +45,12 @@ public class SecretLeaseCreatedEvent extends SecretLeaseEvent {
 	 * {@link Lease} and {@code secrets}.
 	 * @param requestedSecret must not be {@literal null}.
 	 * @param lease must not be {@literal null}.
-	 * @param secrets must not be {@literal null}.
+	 * @param secrets must not be {@literal null}. Values may be {@literal null}
+	 * (for example Vault AWS {@code iam_user} credentials expose a null session token).
 	 */
 	public SecretLeaseCreatedEvent(RequestedSecret requestedSecret, Lease lease, Map<String, Object> secrets) {
 		super(requestedSecret, lease);
-		this.secrets = Map.copyOf(secrets);
+		this.secrets = Collections.unmodifiableMap(new LinkedHashMap<>(secrets));
 	}
 
 

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/lease/event/SecretLeaseCreatedEventUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/lease/event/SecretLeaseCreatedEventUnitTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.vault.core.lease.event;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.vault.core.lease.domain.Lease;
+import org.springframework.vault.core.lease.domain.RequestedSecret;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SecretLeaseCreatedEvent}.
+ *
+ * @author Burak KALAYCI
+ */
+class SecretLeaseCreatedEventUnitTests {
+
+	@Test
+	void shouldAcceptNullSecretValues() {
+
+		Map<String, Object> secrets = new LinkedHashMap<>();
+		secrets.put("access_key", "SOME_KEY");
+		secrets.put("secret_key", "SOME_VALUE");
+		secrets.put("session_token", null);
+
+		SecretLeaseCreatedEvent event = new SecretLeaseCreatedEvent(RequestedSecret.renewable("aws/creds/my-role"),
+				Lease.none(), secrets);
+
+		assertThat(event.getSecrets()).containsEntry("access_key", "SOME_KEY")
+			.containsEntry("secret_key", "SOME_VALUE")
+			.containsEntry("session_token", null);
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> event.getSecrets().put("other", "value"));
+	}
+
+	@Test
+	void shouldAcceptNullSecretValuesOnRotation() {
+
+		Map<String, Object> secrets = new LinkedHashMap<>();
+		secrets.put("access_key", "SOME_KEY");
+		secrets.put("session_token", null);
+
+		SecretLeaseRotatedEvent event = new SecretLeaseRotatedEvent(RequestedSecret.renewable("aws/creds/my-role"),
+				Lease.none(), Lease.fromTimeToLive(Duration.ofMinutes(5)), secrets);
+
+		assertThat(event.getSecrets()).containsEntry("session_token", null);
+	}
+
+}


### PR DESCRIPTION
## Summary

`SecretLeaseCreatedEvent` currently copies secrets with `Map.copyOf`, which rejects null values. Vault secret payloads can contain null entries (for example AWS `iam_user` credentials with a null `session_token`), so lease create/rotate paths throw `NullPointerException` after Spring Vault 4.0.0.

Restore the previous null-tolerant unmodifiable `LinkedHashMap` copy. `SecretLeaseRotatedEvent` inherits the same constructor path.

Fixes #1018

## Test plan

- [x] `./mvnw -pl spring-vault-core -Dtest=SecretLeaseCreatedEventUnitTests,SecretLeaseContainerUnitTests test` (36/36 GREEN)
  - new unit tests cover null values for create and rotate events plus unmodifiable map contract
  - existing `SecretLeaseContainerUnitTests` regression suite