### PR TITLE
fix: VaultSysTemplate: change performanceStandby from primitive boole…

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/core/VaultSysTemplate.java
@@ -461,14 +461,14 @@ public class VaultSysTemplate implements VaultSysOperations {
 
 		VaultHealthImpl(@JsonProperty("initialized") boolean initialized, @JsonProperty("sealed") boolean sealed,
 				@JsonProperty("standby") boolean standby,
-				@JsonProperty("performance_standby") boolean performanceStandby,
+				@Nullable @JsonProperty(value = "performance_standby") Boolean performanceStandby,
 				@Nullable @JsonProperty("replication_dr_mode") String replicationRecoverySecondary,
 				@JsonProperty("server_time_utc") int serverTimeUtc, @Nullable @JsonProperty("version") String version) {
 
 			this.initialized = initialized;
 			this.sealed = sealed;
 			this.standby = standby;
-			this.performanceStandby = performanceStandby;
+			this.performanceStandby = Boolean.TRUE.equals(performanceStandby);
 			this.replicationRecoverySecondary = replicationRecoverySecondary != null
 					&& !"disabled".equalsIgnoreCase(replicationRecoverySecondary);
 			this.serverTimeUtc = serverTimeUtc;

--- a/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/core/VaultSysTemplateUnitTests.java
@@ -41,4 +41,11 @@ class VaultSysTemplateUnitTests {
 		assertThat(enabled.isRecoveryReplicationSecondary()).isTrue();
 	}
 
+	@Test
+	void shouldSetPerformanceStandbyWithDefaultValueFalse(){
+		VaultSysTemplate.VaultHealthImpl emptyPerformanceStandby = new VaultSysTemplate.VaultHealthImpl(true, true, true, null, null, 0, null);
+
+		assertThat(emptyPerformanceStandby.isPerformanceStandby()).isFalse();
+	}
+
 }


### PR DESCRIPTION
fix: VaultSysTemplate: change performanceStandby from primitive boolean to boxed obj to prevent nullable jackson parsing.

fixes gh-#1048