### PR TITLE
Fix four-arg CertificateBundle.of private key type argument

### DIFF
--- a/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
+++ b/spring-vault-core/src/main/java/org/springframework/vault/support/CertificateBundle.java
@@ -95,7 +95,7 @@ public class CertificateBundle extends Certificate {
 		Assert.hasText(issuingCaCertificate, "Issuing CA certificate must not be empty");
 		Assert.hasText(privateKey, "Private key must not be empty");
 		return new CertificateBundle(serialNumber, certificate, issuingCaCertificate,
-				Collections.singletonList(issuingCaCertificate), privateKey, privateKey, null);
+				Collections.singletonList(issuingCaCertificate), privateKey, null, null);
 	}
 
 	/**

--- a/spring-vault-core/src/test/java/org/springframework/vault/support/CertificateBundleUnitTests.java
+++ b/spring-vault-core/src/test/java/org/springframework/vault/support/CertificateBundleUnitTests.java
@@ -107,7 +107,25 @@ class CertificateBundleUnitTests {
 		String privateKey = "aprivatekey";
 
 		CertificateBundle bundle = CertificateBundle.of(serialNumber, certificate, caCertificate, privateKey);
-		assertThat(bundle.getPrivateKey()).isNotNull();
+		assertThat(bundle.getPrivateKey()).isEqualTo(privateKey);
+		assertThat(bundle.getPrivateKeyType()).isNull();
+	}
+
+	@Test
+	void fourArgOfShouldNotTreatPrivateKeyAsPrivateKeyType() throws Exception {
+
+		CertificateBundle fromJson = loadCertificateBundle("certificate-response-rsa-pem.json");
+		CertificateBundle bundle = CertificateBundle.of(fromJson.getSerialNumber(), fromJson.getCertificate(),
+				fromJson.getIssuingCaCertificate(), fromJson.getPrivateKey());
+
+		assertThat(bundle.getPrivateKeyType()).isNull();
+		assertThat(bundle.getPrivateKey()).isEqualTo(fromJson.getPrivateKey());
+
+		CertificateBundle bundleWithType = CertificateBundle.of(fromJson.getSerialNumber(), fromJson.getCertificate(),
+				fromJson.getIssuingCaCertificate(), fromJson.getPrivateKey(), fromJson.getPrivateKeyType());
+		KeyFactory kf = KeyFactory.getInstance("RSA");
+		PrivateKey privateKey = kf.generatePrivate(bundleWithType.getPrivateKeySpec());
+		assertThat(privateKey.getAlgorithm()).isEqualTo("RSA");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Fix the four-argument `CertificateBundle.of(String, String, String, String)` factory so it passes `null` for `privateKeyType` instead of duplicating the PEM private key string.
- Extend `CertificateBundleUnitTests` to assert `getPrivateKeyType()` is null for the four-arg factory and that the five-arg overload still parses RSA keys correctly.

## Problem

The four-arg `of()` method incorrectly passed `privateKey` as both the private key and `privateKeyType` constructor arguments. Callers that later invoked `getPrivateKeySpec()` hit `IllegalArgumentException` because the key type was PEM material rather than `rsa` or `ec`.

## Test plan

- [x] `mvn -pl spring-vault-core -am test -Dtest=CertificateBundleUnitTests -DfailIfNoTests=false` (Temurin 21)

Fixes #1047